### PR TITLE
Fix Neovim plugin bootstrap and init loading

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,5 +14,21 @@ for name in *; do
   fi
 done
 
-git clone https://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
-vim -u ~/.vimrc.bundles +BundleInstall +qa
+mkdir -p "$HOME/.config/nvim"
+if [ ! -f "$HOME/.config/nvim/init.vim" ]; then
+  printf 'source ~/.vimrc\n' > "$HOME/.config/nvim/init.vim"
+fi
+
+PLUG_PATH="${XDG_DATA_HOME:-$HOME/.local/share}/nvim/site/autoload/plug.vim"
+
+if [ ! -f "$PLUG_PATH" ]; then
+  echo "Installing vim-plug to $PLUG_PATH"
+  curl -fLo "$PLUG_PATH" --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+fi
+
+if command -v nvim >/dev/null 2>&1; then
+  nvim --headless -u ~/.vimrc.bundles "+PlugInstall --sync" +qa
+else
+  vim -u ~/.vimrc.bundles "+PlugInstall --sync" +qa
+fi


### PR DESCRIPTION
## Summary
- replace old Vundle install flow with vim-plug bootstrap
- install plugins with headless PlugInstall sync
- ensure Neovim loads existing ~/.vimrc via ~/.config/nvim/init.vim

## Validation
- shell syntax check passed for install.sh
- Neovim reports :NERDTree command available after config shim