### PR TITLE
Document Vim setup and add plugin inventory generator

### DIFF
--- a/PLUGIN_INVENTORY.md
+++ b/PLUGIN_INVENTORY.md
@@ -1,0 +1,69 @@
+# Vim Plugin Inventory
+
+Generated from `vimrc.bundles` by `bin/generate-vim-plugin-inventory`.
+
+| Plugin | State | What it is | Repo |
+|---|---|---|---|
+| `adelarsq/vim-matchit` | Inactive | Extended `%` matching for pairs/tags | https://github.com/adelarsq/vim-matchit |
+| `airblade/vim-gitgutter` | Active | Git diff signs in the gutter | https://github.com/airblade/vim-gitgutter |
+| `BurntSushi/ripgrep` | Inactive | External search tool (not a Vim plugin) | https://github.com/BurntSushi/ripgrep |
+| `christoomey/vim-run-interactive` | Inactive | Run code interactively from Vim | https://github.com/christoomey/vim-run-interactive |
+| `ctrlpvim/ctrlp.vim` | Inactive | Fuzzy file and buffer finder | https://github.com/ctrlpvim/ctrlp.vim |
+| `dense-analysis/ale` | Inactive | Asynchronous linting and fixing | https://github.com/dense-analysis/ale |
+| `dracula/vim` | Inactive | Dracula colorscheme | https://github.com/dracula/vim |
+| `ejholmes/vim-forcedotcom` | Active | Salesforce/Apex support for Vim | https://github.com/ejholmes/vim-forcedotcom |
+| `elzr/vim-json` | Active | Improved JSON syntax support | https://github.com/elzr/vim-json |
+| `epilande/vim-es2015-snippets` | Inactive | ES2015 snippets | https://github.com/epilande/vim-es2015-snippets |
+| `epilande/vim-react-snippets` | Inactive | React snippets | https://github.com/epilande/vim-react-snippets |
+| `flowtype/vim-flow` | Inactive | Flow type syntax support | https://github.com/flowtype/vim-flow |
+| `gavocanov/vim-js-indent` | Inactive | JavaScript indentation tweaks | https://github.com/gavocanov/vim-js-indent |
+| `github/copilot.vim` | Active | GitHub Copilot integration | https://github.com/github/copilot.vim |
+| `godlygeek/tabular` | Inactive | Align text into columns by pattern | https://github.com/godlygeek/tabular |
+| `hail2u/vim-css3-syntax` | Inactive | CSS3 syntax highlighting | https://github.com/hail2u/vim-css3-syntax |
+| `heavenshell/vim-jsdoc` | Inactive | Generate JSDoc comments | https://github.com/heavenshell/vim-jsdoc |
+| `itchyny/lightline.vim` | Active | Lightweight statusline | https://github.com/itchyny/lightline.vim |
+| `jparise/vim-graphql` | Inactive | GraphQL syntax support | https://github.com/jparise/vim-graphql |
+| `junegunn/goyo.vim` | Inactive | Distraction-free writing mode | https://github.com/junegunn/goyo.vim |
+| `junegunn/limelight.vim` | Active | Focus mode that dims surrounding text | https://github.com/junegunn/limelight.vim |
+| `kabouzeid/nvim-lspinstall` | Active | Legacy Neovim LSP installer | https://github.com/kabouzeid/nvim-lspinstall |
+| `kchmck/vim-coffee-script` | Inactive | CoffeeScript syntax and indent support | https://github.com/kchmck/vim-coffee-script |
+| `lambdatoast/elm.vim` | Inactive | Elm language support | https://github.com/lambdatoast/elm.vim |
+| `leafgarland/typescript-vim` | Active | TypeScript syntax and filetype support | https://github.com/leafgarland/typescript-vim |
+| `luochen1990/rainbow` | Active | Rainbow bracket and parenthesis colors | https://github.com/luochen1990/rainbow |
+| `mxw/vim-jsx` | Inactive | JSX syntax support | https://github.com/mxw/vim-jsx |
+| `neovim/nvim-lsp` | Active | Legacy Neovim LSP plugin | https://github.com/neovim/nvim-lsp |
+| `neovim/nvim-lspconfig` | Active | LSP server configurations for Neovim | https://github.com/neovim/nvim-lspconfig |
+| `nvim-lua/plenary.nvim` | Inactive | Lua utility library used by Neovim plugins | https://github.com/nvim-lua/plenary.nvim |
+| `nvim-telescope/telescope.nvim` | Inactive | Fuzzy finder and picker UI | https://github.com/nvim-telescope/telescope.nvim |
+| `nvim-treesitter/nvim-treesitter` | Inactive | Tree-sitter parsing and highlighting | https://github.com/nvim-treesitter/nvim-treesitter |
+| `othree/es.next.syntax.vim` | Inactive | ESNext syntax support | https://github.com/othree/es.next.syntax.vim |
+| `othree/javascript-libraries-syntax.vim` | Inactive | JavaScript library and framework syntax add-ons | https://github.com/othree/javascript-libraries-syntax.vim |
+| `othree/yajs.vim` | Inactive | Improved JavaScript syntax | https://github.com/othree/yajs.vim |
+| `pangloss/vim-javascript` | Active | JavaScript syntax and highlighting | https://github.com/pangloss/vim-javascript |
+| `pbrisbin/vim-mkdir` | Inactive | Auto-create missing directories on save | https://github.com/pbrisbin/vim-mkdir |
+| `peitalin/vim-jsx-typescript` | Inactive | TypeScript JSX (TSX) syntax support | https://github.com/peitalin/vim-jsx-typescript |
+| `plasticboy/vim-markdown` | Inactive | Markdown editing and syntax support | https://github.com/plasticboy/vim-markdown |
+| `prettier/vim-prettier` | Inactive | Prettier formatter integration | https://github.com/prettier/vim-prettier |
+| `rizzatti/dash.vim` | Inactive | Dash.app documentation lookup | https://github.com/rizzatti/dash.vim |
+| `ryanoasis/vim-devicons` | Active | Filetype icons for plugin UIs | https://github.com/ryanoasis/vim-devicons |
+| `sainnhe/vim-color-forest-night` | Active | Forest Night colorscheme | https://github.com/sainnhe/vim-color-forest-night |
+| `scrooloose/nerdcommenter` | Active | Comment/uncomment utilities | https://github.com/scrooloose/nerdcommenter |
+| `scrooloose/nerdtree` | Active | File explorer tree sidebar | https://github.com/scrooloose/nerdtree |
+| `sharkdp/fd` | Inactive | External `find` alternative (not a Vim plugin) | https://github.com/sharkdp/fd |
+| `sheerun/vim-polyglot` | Inactive | Language pack with many syntax files | https://github.com/sheerun/vim-polyglot |
+| `SirVer/ultisnips` | Inactive | Snippet engine | https://github.com/SirVer/ultisnips |
+| `slim-template/vim-slim` | Inactive | Slim template syntax support | https://github.com/slim-template/vim-slim |
+| `styled-components/vim-styled-components` | Inactive | styled-components syntax support | https://github.com/styled-components/vim-styled-components |
+| `terryma/vim-multiple-cursors` | Inactive | Multiple cursors editing | https://github.com/terryma/vim-multiple-cursors |
+| `thoughtbot/vim-rspec` | Inactive | RSpec test runner helpers | https://github.com/thoughtbot/vim-rspec |
+| `tpope/vim-bundler` | Inactive | Bundler-aware commands | https://github.com/tpope/vim-bundler |
+| `tpope/vim-endwise` | Inactive | Auto-add `end` in Ruby-like languages | https://github.com/tpope/vim-endwise |
+| `tpope/vim-eunuch` | Inactive | Shell and file operations from Vim commands | https://github.com/tpope/vim-eunuch |
+| `tpope/vim-fugitive` | Inactive | Git integration for Vim | https://github.com/tpope/vim-fugitive |
+| `tpope/vim-obsession` | Inactive | Session management | https://github.com/tpope/vim-obsession |
+| `tpope/vim-rails` | Inactive | Rails navigation and helpers | https://github.com/tpope/vim-rails |
+| `tpope/vim-repeat` | Inactive | Better repeat support for plugin commands | https://github.com/tpope/vim-repeat |
+| `tpope/vim-surround` | Inactive | Add/change/delete surroundings | https://github.com/tpope/vim-surround |
+| `vim-ruby/vim-ruby` | Inactive | Ruby syntax and filetype support | https://github.com/vim-ruby/vim-ruby |
+| `vim-scripts/tComment` | Inactive | Comment toggling plugin | https://github.com/vim-scripts/tComment |
+| `williamboman/nvim-lsp-installer` | Active | Legacy LSP installer plugin | https://github.com/williamboman/nvim-lsp-installer |

--- a/README.md
+++ b/README.md
@@ -1,14 +1,38 @@
 # Dotfiles
 
-Personal shell/editor/tmux dotfiles with a bootstrap script and small utility commands.
+Personal shell, editor, and tmux configuration with a bootstrap installer.
+
+## Contents
+
+- [What this repo manages](#what-this-repo-manages)
+- [Requirements](#requirements)
+- [Install](#install)
+- [How install works](#how-install-works)
+- [Neovim and Vim](#neovim-and-vim)
+- [Plugin management](#plugin-management)
+- [Key mappings and usage](#key-mappings-and-usage)
+- [tmux](#tmux)
+- [Local machine overrides](#local-machine-overrides)
+- [Troubleshooting](#troubleshooting)
+- [Optional macOS bootstrap](#optional-macos-bootstrap)
+
+## What this repo manages
+
+- `zshrc` and `zsh/`: shell options, prompt, completions, and shell helpers.
+- `aliases`: command aliases for git/workflow shortcuts.
+- `vimrc*` and `vim/`: Vim + Neovim settings and plugin config.
+- `tmux.conf` and `.tmux/`: tmux behavior and TPM plugin setup.
+- `bin/`: utility scripts (`git-churn`, `replace`, `tat`, etc).
 
 ## Requirements
 
-- macOS or Linux with `zsh`
+- macOS or Linux
+- `zsh`
 - `git`
+- `curl`
 - `vim` or `nvim`
 
-Set your login shell to zsh if needed:
+Set login shell to zsh if needed:
 
 ```sh
 chsh -s /bin/zsh
@@ -16,69 +40,210 @@ chsh -s /bin/zsh
 
 ## Install
 
-Clone the repo and run the installer:
-
 ```sh
 git clone <your-repo-url> ~/dotfiles
 cd ~/dotfiles
 ./install.sh
 ```
 
-`install.sh` symlinks repo files into `$HOME` as dotfiles (for example `zshrc` -> `~/.zshrc`), and warns if a target exists but is not a symlink.
+## How install works
 
-## What This Config Includes
+`install.sh` performs these steps:
 
-- `zshrc` and `zsh/`: shell options, prompt, completions, custom functions.
-- `aliases`: shell aliases for git, rails, test helpers, and common commands.
-- `vimrc*` and `vim/`: Vim/Neovim settings and plugins.
-- `tmux.conf` and `.tmux/`: tmux keybindings and TPM plugin config.
-- `bin/`: small helper scripts (`git-churn`, `replace`, `tat`).
+1. Symlinks each top-level repo item to `$HOME` as a dotfile.
+1. Skips only `install.sh` and `README.md`.
+1. Warns (does not overwrite) if a destination exists and is not a symlink.
+1. Creates `~/.config/nvim/init.vim` (if missing) with `source ~/.vimrc`.
+1. Installs `vim-plug` for Neovim into:
+   - `${XDG_DATA_HOME:-$HOME/.local/share}/nvim/site/autoload/plug.vim`
+1. Runs plugin install:
+   - `nvim --headless -u ~/.vimrc.bundles "+PlugInstall --sync" +qa`
+   - falls back to `vim` if `nvim` is unavailable.
 
-## Local Overrides
+## Neovim and Vim
 
-Machine-specific overrides are supported:
+This repo uses a classic Vim-style config layout:
 
-- `~/.aliases.local` for personal aliases.
-- `~/.vimrc.bundles.local` for machine-specific Vim plugins.
-- `~/.zshrc.local` is used by the `mac` bootstrap script for PATH/appends when writable.
+- `vimrc` is the main entrypoint and sources:
+  - `~/.vimrc.bundles`
+  - `~/.vimrc.global`
+  - `~/.vimrc.plugins`
+  - `~/.vimrc.macros`
+  - `~/.vimrc.local`
 
-## Vim Plugin Setup
+Neovim compatibility is handled via `~/.config/nvim/init.vim` sourcing `~/.vimrc`.
 
-The current `vimrc.bundles` uses `vim-plug` (`plug#begin`/`Plug` entries). If plugins are not installed yet, run:
+### Leader key
 
-```sh
-vim +PlugInstall +qa
+Leader is comma:
+
+```vim
+let mapleader = ","
 ```
 
-## Optional macOS Bootstrap
+## Plugin management
 
-The `mac` script is a larger machine bootstrap for Homebrew + common dev tools:
+Plugins are managed with `vim-plug` in [`vimrc.bundles`](vimrc.bundles) via `Plug` entries.
+
+Install/update plugins:
 
 ```sh
-./mac
+nvim --headless -u ~/.vimrc.bundles "+PlugInstall --sync" +qa
 ```
 
-Use it only if you want those opinionated system-level changes.
+Clean removed plugins:
+
+```sh
+nvim --headless -u ~/.vimrc.bundles "+PlugClean!" +qa
+```
+
+### Notable enabled plugins
+
+- `scrooloose/nerdtree` (file explorer)
+- `ryanoasis/vim-devicons` (icons)
+- `scrooloose/nerdcommenter` (comment toggling)
+- `junegunn/limelight.vim` (focus mode)
+- `airblade/vim-gitgutter`
+- `itchyny/lightline.vim`
+- `github/copilot.vim`
+- `neovim/nvim-lspconfig`
+
+## Key mappings and usage
+
+### NERDTree
+
+- `Ctrl+t`: toggle NERDTree
+- `,n`: reveal current file in tree
+- Opens automatically on startup (`autocmd vimenter * NERDTree`)
+
+Bookmarks:
+
+- `NERDTreeShowBookmarks = 1` means bookmarks section is visible.
+- Bookmarks are quick named shortcuts to frequently used paths.
+
+### Comment toggle
+
+- `,/` in normal mode: toggle comment on current line
+- `,/` in visual mode: toggle comments on selection
+
+Configured using:
+
+```vim
+call nerdcommenter#Comment('n', 'toggle')
+call nerdcommenter#Comment('x', 'toggle')
+```
+
+### Limelight
+
+- `Ctrl+l`: Limelight focus mode mapping
+- `Ctrl+l l`: toggle `:Limelight!!`
+
+### General navigation
+
+- `,,`: switch to last file
+- `Ctrl+h/j/k/l`: window navigation
+- `<leader>w`: save
+- `<leader>x`: save and quit
+- `<leader>q`: quit
+
+## tmux
+
+### Prefix
+
+Prefix is `Ctrl+a` (default `Ctrl+b` is unbound).
+
+### Useful behavior
+
+- Vim-like pane navigation with `h/j/k/l`
+- Split windows in current pane path
+- Mouse toggle:
+  - `prefix + m` enables mouse
+  - `prefix + M` disables mouse
+- Copy mode uses vi keys and copies to macOS clipboard via `reattach-to-user-namespace` when available.
+
+### Plugins
+
+Configured with TPM:
+
+- `tmux-plugins/tpm`
+- `tmux-plugins/tmux-sensible`
+- `tmux-plugins/tmux-resurrect`
+- `tmux-plugins/tmux-battery`
+
+## Local machine overrides
+
+Use local files for machine-specific customization:
+
+- `~/.aliases.local`
+- `~/.vimrc.bundles.local`
+- `~/.vimrc.local`
+- `~/.zshrc.local`
+
+These are sourced conditionally if present.
 
 ## Troubleshooting
 
-### tmux keybindings not working
+### Neovim opens but your config/plugins are missing
 
-If tmux starts with default bindings, make sure your config is linked:
+Check these files exist and are linked:
+
+```sh
+ls -la ~/.vimrc ~/.vimrc.bundles ~/.config/nvim/init.vim
+```
+
+`~/.config/nvim/init.vim` should contain:
+
+```vim
+source ~/.vimrc
+```
+
+Then resync plugins:
+
+```sh
+nvim --headless -u ~/.vimrc.bundles "+PlugInstall --sync" +qa
+```
+
+### NERDTree icons show squares/garbled glyphs
+
+Install a Nerd Font and set it in your terminal profile.
+
+Example on macOS (Homebrew):
+
+```sh
+brew install --cask font-jetbrains-mono-nerd-font
+```
+
+This repo also has a fallback in [`vimrc.plugins`](vimrc.plugins):
+
+- default: Nerd Font icons enabled
+- set `DOTFILES_NERD_FONT=0` to force ASCII-safe arrows and disable devicons
+
+### `:NERDTree` command not found
+
+- Ensure `nerdtree` is enabled in [`vimrc.bundles`](vimrc.bundles).
+- Run plugin sync (`PlugInstall`).
+- Restart Neovim or run:
+
+```vim
+:source ~/.vimrc
+```
+
+### tmux keybindings not applying
+
+Ensure config is linked:
 
 ```sh
 ln -s ~/dotfiles/tmux.conf ~/.tmux.conf
 ```
 
-Then reload tmux config in a running session:
+Reload tmux config:
 
 ```sh
 tmux source-file ~/.tmux.conf
 ```
 
-This config uses prefix `Ctrl-a` (not default `Ctrl-b`).
+## Optional macOS bootstrap
 
-If copy or resurrect commands fail, install dependencies/plugins:
+`./mac` is a larger machine bootstrap for Homebrew and related tools.
 
-- `reattach-to-user-namespace`
-- TPM + configured tmux plugins under `~/.tmux/plugins`
+Use it only if you want those opinionated system-level changes.

--- a/bin/generate-vim-plugin-inventory
+++ b/bin/generate-vim-plugin-inventory
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUNDLES_FILE="$ROOT_DIR/vimrc.bundles"
+OUT_FILE="$ROOT_DIR/PLUGIN_INVENTORY.md"
+
+if [[ ! -f "$BUNDLES_FILE" ]]; then
+  echo "Missing $BUNDLES_FILE" >&2
+  exit 1
+fi
+
+awk '
+  function desc(p) {
+    d["christoomey/vim-run-interactive"] = "Run code interactively from Vim"
+    d["adelarsq/vim-matchit"] = "Extended `%` matching for pairs/tags"
+    d["kchmck/vim-coffee-script"] = "CoffeeScript syntax and indent support"
+    d["ctrlpvim/ctrlp.vim"] = "Fuzzy file and buffer finder"
+    d["pbrisbin/vim-mkdir"] = "Auto-create missing directories on save"
+    d["scrooloose/nerdtree"] = "File explorer tree sidebar"
+    d["preservim/nerdtree"] = "File explorer tree sidebar"
+    d["slim-template/vim-slim"] = "Slim template syntax support"
+    d["thoughtbot/vim-rspec"] = "RSpec test runner helpers"
+    d["tpope/vim-bundler"] = "Bundler-aware commands"
+    d["tpope/vim-endwise"] = "Auto-add `end` in Ruby-like languages"
+    d["tpope/vim-eunuch"] = "Shell and file operations from Vim commands"
+    d["tpope/vim-fugitive"] = "Git integration for Vim"
+    d["tpope/vim-obsession"] = "Session management"
+    d["luochen1990/rainbow"] = "Rainbow bracket and parenthesis colors"
+    d["tpope/vim-rails"] = "Rails navigation and helpers"
+    d["tpope/vim-repeat"] = "Better repeat support for plugin commands"
+    d["tpope/vim-surround"] = "Add/change/delete surroundings"
+    d["vim-ruby/vim-ruby"] = "Ruby syntax and filetype support"
+    d["vim-scripts/tComment"] = "Comment toggling plugin"
+    d["hail2u/vim-css3-syntax"] = "CSS3 syntax highlighting"
+    d["sheerun/vim-polyglot"] = "Language pack with many syntax files"
+    d["rizzatti/dash.vim"] = "Dash.app documentation lookup"
+    d["lambdatoast/elm.vim"] = "Elm language support"
+    d["pangloss/vim-javascript"] = "JavaScript syntax and highlighting"
+    d["gavocanov/vim-js-indent"] = "JavaScript indentation tweaks"
+    d["itchyny/lightline.vim"] = "Lightweight statusline"
+    d["airblade/vim-gitgutter"] = "Git diff signs in the gutter"
+    d["mxw/vim-jsx"] = "JSX syntax support"
+    d["othree/yajs.vim"] = "Improved JavaScript syntax"
+    d["othree/es.next.syntax.vim"] = "ESNext syntax support"
+    d["othree/javascript-libraries-syntax.vim"] = "JavaScript library and framework syntax add-ons"
+    d["flowtype/vim-flow"] = "Flow type syntax support"
+    d["epilande/vim-es2015-snippets"] = "ES2015 snippets"
+    d["epilande/vim-react-snippets"] = "React snippets"
+    d["SirVer/ultisnips"] = "Snippet engine"
+    d["heavenshell/vim-jsdoc"] = "Generate JSDoc comments"
+    d["godlygeek/tabular"] = "Align text into columns by pattern"
+    d["plasticboy/vim-markdown"] = "Markdown editing and syntax support"
+    d["elzr/vim-json"] = "Improved JSON syntax support"
+    d["junegunn/limelight.vim"] = "Focus mode that dims surrounding text"
+    d["junegunn/goyo.vim"] = "Distraction-free writing mode"
+    d["dracula/vim"] = "Dracula colorscheme"
+    d["prettier/vim-prettier"] = "Prettier formatter integration"
+    d["scrooloose/nerdcommenter"] = "Comment/uncomment utilities"
+    d["preservim/nerdcommenter"] = "Comment/uncomment utilities"
+    d["terryma/vim-multiple-cursors"] = "Multiple cursors editing"
+    d["sainnhe/vim-color-forest-night"] = "Forest Night colorscheme"
+    d["leafgarland/typescript-vim"] = "TypeScript syntax and filetype support"
+    d["peitalin/vim-jsx-typescript"] = "TypeScript JSX (TSX) syntax support"
+    d["styled-components/vim-styled-components"] = "styled-components syntax support"
+    d["jparise/vim-graphql"] = "GraphQL syntax support"
+    d["neovim/nvim-lspconfig"] = "LSP server configurations for Neovim"
+    d["kabouzeid/nvim-lspinstall"] = "Legacy Neovim LSP installer"
+    d["neovim/nvim-lsp"] = "Legacy Neovim LSP plugin"
+    d["williamboman/nvim-lsp-installer"] = "Legacy LSP installer plugin"
+    d["github/copilot.vim"] = "GitHub Copilot integration"
+    d["nvim-lua/plenary.nvim"] = "Lua utility library used by Neovim plugins"
+    d["nvim-telescope/telescope.nvim"] = "Fuzzy finder and picker UI"
+    d["BurntSushi/ripgrep"] = "External search tool (not a Vim plugin)"
+    d["sharkdp/fd"] = "External `find` alternative (not a Vim plugin)"
+    d["nvim-treesitter/nvim-treesitter"] = "Tree-sitter parsing and highlighting"
+    d["ryanoasis/vim-devicons"] = "Filetype icons for plugin UIs"
+    d["ejholmes/vim-forcedotcom"] = "Salesforce/Apex support for Vim"
+    d["dense-analysis/ale"] = "Asynchronous linting and fixing"
+
+    if (p in d) return d[p]
+    return "Vim/Neovim plugin or external tooling dependency"
+  }
+
+  function state_for(p) {
+    if (active[p] && inactive[p]) return "Both"
+    if (active[p]) return "Active"
+    return "Inactive"
+  }
+
+  function normalize(plugin) {
+    gsub(/^https?:\/\/github\.com\//, "", plugin)
+    gsub(/\.git$/, "", plugin)
+    return plugin
+  }
+
+  {
+    line = $0
+    is_inactive = (line ~ /^[[:space:]]*"/)
+    plug_start = index(line, "Plug '\''")
+    if (plug_start > 0) {
+      rest = substr(line, plug_start + 6)
+      quote_end = index(rest, "'\''")
+      if (quote_end <= 0) next
+      p = normalize(substr(rest, 1, quote_end - 1))
+      seen[p] = 1
+      if (is_inactive) inactive[p] = 1
+      else active[p] = 1
+    }
+  }
+
+  END {
+    print "# Vim Plugin Inventory"
+    print ""
+    print "Generated from `vimrc.bundles` by `bin/generate-vim-plugin-inventory`."
+    print ""
+    print "| Plugin | State | What it is | Repo |"
+    print "|---|---|---|---|"
+
+    for (p in seen) {
+      print p "\t" state_for(p) "\t" desc(p) "\t" "https://github.com/" p
+    }
+  }
+' "$BUNDLES_FILE" | {
+  # Preserve header lines as-is, sort only table body rows.
+  IFS= read -r l1
+  IFS= read -r l2
+  IFS= read -r l3
+  IFS= read -r l4
+  IFS= read -r l5
+  IFS= read -r l6
+  printf '%s\n' "$l1" "$l2" "$l3" "$l4" "$l5" "$l6"
+  sort -f
+} | awk -F '\t' '
+  BEGIN { OFS = "" }
+  /^[#|]/ || /^Generated from/ || /^$/ { print; next }
+  { print "| `", $1, "` | ", $2, " | ", $3, " | ", $4, " |" }
+' > "$OUT_FILE"
+
+echo "Wrote $OUT_FILE"

--- a/vimrc.plugins
+++ b/vimrc.plugins
@@ -3,6 +3,21 @@ noremap <C-T> :NERDTreeToggle<CR>
 nmap <leader>n :NERDTreeFind<CR>R
 autocmd vimenter * NERDTree
 autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTree") && b:NERDTree.isTabTree()) | q | endif
+" Nerd Font fallback:
+" - Use Nerd Font icons by default.
+" - Set DOTFILES_NERD_FONT=0 to force ASCII-safe rendering on machines without Nerd Fonts.
+" - This avoids tofu/square glyphs when terminal font lacks Nerd glyphs.
+if !exists('g:dotfiles_use_nerd_font')
+  let g:dotfiles_use_nerd_font = !(exists('$DOTFILES_NERD_FONT') && $DOTFILES_NERD_FONT ==# '0')
+endif
+if g:dotfiles_use_nerd_font
+  let g:NERDTreeDirArrowExpandable = '👉'
+  let g:NERDTreeDirArrowCollapsible = '👇'
+else
+  let g:webdevicons_enable = 0
+  let g:NERDTreeDirArrowExpandable = '+'
+  let g:NERDTreeDirArrowCollapsible = '~'
+endif
 " NERDTress File highlighting
 function! NERDTreeHighlightFile(extension, guifg)
  exec 'autocmd filetype nerdtree highlight ' . a:extension .' guifg='. a:guifg
@@ -20,8 +35,6 @@ call NERDTreeHighlightFile('js','#CACB42')
 call NERDTreeHighlightFile('ts', '#3078C6')
 call NERDTreeHighlightFile('tsx','#3078C6')
 call NERDTreeHighlightFile('php','#ff00ff')
-let g:NERDTreeDirArrowExpandable = '👉'
-let g:NERDTreeDirArrowCollapsible = '👇'
 " Make bookmarks Visible
 let NERDTreeShowBookmarks = 1
 "Enable Colors
@@ -29,16 +42,8 @@ let NERDChristmasTree = 1
 
 " Nerdcommenter
 " ,/ to invert comment on the current line/selection
-nnoremap <leader>/ :call NERDComment(0, "invert")<cr>
-vnoremap <leader>/ :call NERDComment(0, "invert")<cr>
-
-" Tabularize
-if exists(":Tabularize")
-  nnoremap <Leader>l= :Tabularize /=<CR>
-  vnoremap <Leader>l= :Tabularize /=<CR>
-  nnoremap <Leader>l: :Tabularize /:\zs<CR>
-  vnoremap <Leader>l: :Tabularize /:\zs<CR>
-endif
+nnoremap <leader>/ :call nerdcommenter#Comment('n', 'toggle')<cr>
+vnoremap <leader>/ :call nerdcommenter#Comment('x', 'toggle')<cr>
 
 " LimeLight "
 nmap <C-l> <Plug>(Limelight)


### PR DESCRIPTION
## Summary
- expand README with comprehensive setup and troubleshooting details
- update NERDCommenter mappings to non-deprecated API
- add generated Vim plugin inventory (active and inactive plugins)
- add bin/generate-vim-plugin-inventory to refresh inventory from vimrc.bundles

## Notes
- left .nvimlog untracked and uncommitted