### PR TITLE
fix(zsh): reconcile dotfiles zshrc so it can own the login shell

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -6,7 +6,7 @@ done
 # extra files in ~/.zsh/configs/pre , ~/.zsh/configs , and ~/.zsh/configs/post
 # these are loaded first, second, and third, respectively.
 _load_settings() {
-  _dir="$2"
+  _dir="$1"
   if [ -d "$_dir" ]; then
     if [ -d "$_dir/pre" ]; then
       for config in "$_dir"/pre/**/*(N-.); do
@@ -74,13 +74,20 @@ fi
 export PATH="/Applications/Racket v8.10/bin:$PATH"
 
 # Java
-# Setting JAVA_HOME to the preferred version and adding Java binaries to PATH
-export JAVA_HOME=$(/usr/libexec/java_home -v 21)
-export PATH="$JAVA_HOME/bin:$PATH"
+# Setting JAVA_HOME to the preferred version and adding Java binaries to PATH.
+# Guard on availability so shells don't error when JDK 21 isn't installed.
+if /usr/libexec/java_home -v 21 >/dev/null 2>&1; then
+  export JAVA_HOME="$(/usr/libexec/java_home -v 21)"
+  export PATH="$JAVA_HOME/bin:$PATH"
+fi
 
 # Python
 # Adding Python binaries to PATH, set by pipx
 export PATH="$PATH:$HOME/Library/Python/3.9/bin"
 export PATH="$PATH:$HOME/.local/bin"
+
+# Machine-specific overrides (secrets, tool completions, per-host tweaks).
+# Kept out of the repo; sourced last so it can override anything above.
+[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
 
 # End of .zshrc configuration


### PR DESCRIPTION
## Summary

Make the dotfiles `zshrc` usable as the actual `~/.zshrc`. Previously the machine's `~/.zshrc` was a standalone hand-written file that bypassed the dotfiles zsh system entirely; adopting the dotfiles version surfaced three latent bugs, fixed here.

## Changes (`zshrc`)

1. **Repair the config loader.** `_load_settings()` read `$2` but is called with a single argument, so `_dir` was empty, `[ -d "" ]` was false, and the **entire `zsh/configs/` tree was silently skipped** — aliases, prompt, keybindings, colors, and history never loaded. Changed to `$1`.
2. **Guard the Java block.** `export JAVA_HOME=$(/usr/libexec/java_home -v 21)` ran unconditionally and printed `Unable to locate a Java Runtime` into every shell on machines without JDK 21. Now wrapped in an availability check.
3. **Wire `~/.zshrc.local`.** The README documents a `~/.zshrc.local` override, but nothing sourced it. Now sourced last so machine-specific settings/secrets can live outside the repo.

## Verification

Fresh login shell after pointing `~/.zshrc` at the dotfiles copy:

- Config tree loads: `vim`/`vi` → `nvim`, `tlf`, `b`, `ll` aliases present; shell functions (`g`) available.
- No Java error; `JAVA_HOME` empty when JDK 21 absent (guard works).
- `~/.zshrc.local` overrides load (machine `exa` alias, bun PATH, tool completions, env) — kept out of the repo.
- Only non-interactive-test noise was `stty: stdin isn't a terminal` from `keybindings.zsh`; it does not occur in a real terminal.

> Machine-side steps (not in this PR): `~/.zshrc` was backed up and repointed to `~/dotfiles/zshrc`, and machine-specific settings were moved into `~/.zshrc.local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)