### PR TITLE
fix: improve NERDTree markdown file contrast

### DIFF
--- a/vimrc.plugins
+++ b/vimrc.plugins
@@ -23,7 +23,7 @@ function! NERDTreeHighlightFile(extension, guifg)
  exec 'autocmd filetype nerdtree highlight ' . a:extension .' guifg='. a:guifg
  exec 'autocmd filetype nerdtree syn match ' . a:extension .' #^\s\+.*'. a:extension .'$#'
 endfunction
-call NERDTreeHighlightFile('md', 'blue')
+call NERDTreeHighlightFile('md', '#7FBBB3')
 call NERDTreeHighlightFile('yml', 'yellow')
 call NERDTreeHighlightFile('config', 'yellow')
 call NERDTreeHighlightFile('conf', 'yellow')


### PR DESCRIPTION
## Summary
- Change NERDTree `.md` file highlight from named `blue` to Everforest aqua `#7FBBB3` for better readability on dark backgrounds

## Test plan
- [x] `nvim --headless -u ~/.vimrc` loads without error
- [ ] Open NERDTree and confirm `.md` files are clearly visible against the Everforest background

Made with [Cursor](https://cursor.com)