### PR TITLE
feat(vim): add modern TypeScript support

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -41,7 +41,7 @@ Terminal app (Ghostty / iTerm / etc.)
 | `Ctrl+t` | Toggle file tree (NERDTree) |
 | `,w` / `,q` | Save / quit (Neovim) |
 | `,/` | Toggle comment |
-| `K` | Grep word under cursor |
+| `K` | Grep word under cursor; LSP hover in attached buffers |
 | `Ctrl+h/j/k/l` | Move between nvim splits |
 | `g` | `git status` (no args) or `git …` |
 | `tat` | Attach tmux session for current directory |
@@ -326,6 +326,9 @@ restore relaunches with `--session` or `--resume`. Debug mapping:
 
 Colorscheme: **Kanagawa** (`wave` dark). `vim`/`vi` both launch nvim.
 
+For the complete JS/JSX/TS/TSX workflow, see the
+[Neovim TypeScript cheatsheet](docs/NVIM_TYPESCRIPT_CHEATSHEET.md).
+
 ### Modes
 
 | Key | Mode |
@@ -431,11 +434,12 @@ After uncommenting or adding a `Plug` line in `vimrc.bundles`:
 
 ```sh
 nvim --headless -u ~/.vimrc.bundles "+PlugInstall --sync" +qa   # install/update
-nvim --headless -u ~/.vimrc.bundles "+PlugClean!" +qa          # remove disabled plugins
+nvim --headless -u ~/.vimrc.bundles "+lua require('nvim-treesitter').install({'javascript','jsdoc','typescript','tsx'}):wait(300000)" +qa
 bin/generate-vim-plugin-inventory                              # refresh PLUGIN_INVENTORY.md
 ```
 
 `./install.sh` runs the install step too. Re-open files or run `,sv` / `:Sleuth` so new plugins apply to already-open buffers.
+Do not run `PlugClean!` as part of normal TypeScript support verification.
 
 ### Plugins — your mappings
 
@@ -487,14 +491,51 @@ bin/generate-vim-plugin-inventory                              # refresh PLUGIN_
 
 #### LSP (built-in Neovim + lspconfig)
 
-| Command | Action |
-|---------|--------|
+Semantic mappings require an attached client. For JS/JSX/TS/TSX, `:LspInfo`
+should show exactly one `ts_ls` client launched through
+`typescript-language-server --stdio`.
+
+| Key / command | Action |
+|---------------|--------|
 | `:LspInfo` / `:checkhealth vim.lsp` | Server status |
-| `gd` | Go to definition |
-| `gr` | References |
-| `K` | Hover (overridden in your config for grep) |
-| `gi` | Go to implementation |
+| `gd` | Definition |
+| `K` | Hover in attached buffers; grep remains global elsewhere |
+| `grr` | References |
+| `gri` | Implementation |
+| `grn` | Rename |
+| `gra` | Code actions |
+| `[d` / `]d` | Previous / next diagnostic with float |
+| `,ih` | Toggle inlay hints off/on for the current buffer |
+| `:LspTypescriptSourceAction` | Explicit TypeScript source actions |
+| `:LspTypescriptGoToSourceDefinition` | Go to original TypeScript source definition |
+| `Ctrl+N` / `Ctrl+P` / `Ctrl+Y` | Navigate and accept native completion menu |
 | `Ctrl+o` / `Ctrl+i` | Jump back / forward |
+
+Diagnostics use ASCII signs, warning/error underlines, inline virtual text for
+errors only, and bordered detail floats.
+
+#### TypeScript formatting and linting
+
+| Key / command | Action |
+|---------------|--------|
+| `,fm` | Format with Prettier; local preferred, global explicit fallback allowed |
+| `:ConformInfo` | Formatter resolution and troubleshooting |
+| `,ll` | Lint with ESLint; local preferred, global explicit fallback allowed |
+| `:DotfilesTypeScriptLintDisable` | Disable automatic ESLint for the current buffer |
+
+Save-time Prettier runs only when `node_modules/.bin/prettier` is found upward
+from the buffer. Save-time ESLint runs only when local ESLint and a flat/legacy
+config are both found. Saves never fall back to global Prettier/ESLint and never
+run TypeScript organize-imports or fix-all source actions.
+
+#### TypeScript health checks
+
+```sh
+zsh -lic 'nvim --version | head -n1'
+zsh -lic 'tree-sitter --version'
+zsh -lic 'command -v typescript-language-server && typescript-language-server --version'
+zsh -lic 'bin/check-nvim-typescript-support'
+```
 
 ### Terminal inside nvim
 

--- a/PLUGIN_INVENTORY.md
+++ b/PLUGIN_INVENTORY.md
@@ -25,23 +25,20 @@ Generated from `vimrc.bundles` by `bin/generate-vim-plugin-inventory`.
 | `jparise/vim-graphql` | Inactive | GraphQL syntax support | https://github.com/jparise/vim-graphql |
 | `junegunn/goyo.vim` | Inactive | Distraction-free writing mode | https://github.com/junegunn/goyo.vim |
 | `junegunn/limelight.vim` | Active | Focus mode that dims surrounding text | https://github.com/junegunn/limelight.vim |
-| `kabouzeid/nvim-lspinstall` | Active | Legacy Neovim LSP installer | https://github.com/kabouzeid/nvim-lspinstall |
 | `kchmck/vim-coffee-script` | Inactive | CoffeeScript syntax and indent support | https://github.com/kchmck/vim-coffee-script |
 | `lambdatoast/elm.vim` | Inactive | Elm language support | https://github.com/lambdatoast/elm.vim |
-| `leafgarland/typescript-vim` | Active | TypeScript syntax and filetype support | https://github.com/leafgarland/typescript-vim |
 | `luochen1990/rainbow` | Active | Rainbow bracket and parenthesis colors | https://github.com/luochen1990/rainbow |
+| `mfussenegger/nvim-lint` | Active | Asynchronous linting through external linters | https://github.com/mfussenegger/nvim-lint |
 | `mxw/vim-jsx` | Inactive | JSX syntax support | https://github.com/mxw/vim-jsx |
-| `neovim/nvim-lsp` | Active | Legacy Neovim LSP plugin | https://github.com/neovim/nvim-lsp |
 | `neovim/nvim-lspconfig` | Active | LSP server configurations for Neovim | https://github.com/neovim/nvim-lspconfig |
 | `nvim-lua/plenary.nvim` | Inactive | Lua utility library used by Neovim plugins | https://github.com/nvim-lua/plenary.nvim |
 | `nvim-telescope/telescope.nvim` | Inactive | Fuzzy finder and picker UI | https://github.com/nvim-telescope/telescope.nvim |
-| `nvim-treesitter/nvim-treesitter` | Inactive | Tree-sitter parsing and highlighting | https://github.com/nvim-treesitter/nvim-treesitter |
+| `nvim-treesitter/nvim-treesitter` | Active | Tree-sitter parsing and highlighting | https://github.com/nvim-treesitter/nvim-treesitter |
 | `othree/es.next.syntax.vim` | Inactive | ESNext syntax support | https://github.com/othree/es.next.syntax.vim |
 | `othree/javascript-libraries-syntax.vim` | Inactive | JavaScript library and framework syntax add-ons | https://github.com/othree/javascript-libraries-syntax.vim |
 | `othree/yajs.vim` | Inactive | Improved JavaScript syntax | https://github.com/othree/yajs.vim |
 | `pangloss/vim-javascript` | Active | JavaScript syntax and highlighting | https://github.com/pangloss/vim-javascript |
 | `pbrisbin/vim-mkdir` | Inactive | Auto-create missing directories on save | https://github.com/pbrisbin/vim-mkdir |
-| `peitalin/vim-jsx-typescript` | Inactive | TypeScript JSX (TSX) syntax support | https://github.com/peitalin/vim-jsx-typescript |
 | `plasticboy/vim-markdown` | Inactive | Markdown editing and syntax support | https://github.com/plasticboy/vim-markdown |
 | `prettier/vim-prettier` | Inactive | Prettier formatter integration | https://github.com/prettier/vim-prettier |
 | `rebelot/kanagawa.nvim` | Active | Kanagawa colorscheme inspired by Hokusai | https://github.com/rebelot/kanagawa.nvim |
@@ -54,6 +51,7 @@ Generated from `vimrc.bundles` by `bin/generate-vim-plugin-inventory`.
 | `sheerun/vim-polyglot` | Inactive | Language pack with many syntax files | https://github.com/sheerun/vim-polyglot |
 | `SirVer/ultisnips` | Inactive | Snippet engine | https://github.com/SirVer/ultisnips |
 | `slim-template/vim-slim` | Inactive | Slim template syntax support | https://github.com/slim-template/vim-slim |
+| `stevearc/conform.nvim` | Active | Lightweight formatter integration for Neovim | https://github.com/stevearc/conform.nvim |
 | `styled-components/vim-styled-components` | Inactive | styled-components syntax support | https://github.com/styled-components/vim-styled-components |
 | `terryma/vim-multiple-cursors` | Inactive | Multiple cursors editing | https://github.com/terryma/vim-multiple-cursors |
 | `thoughtbot/vim-rspec` | Inactive | RSpec test runner helpers | https://github.com/thoughtbot/vim-rspec |
@@ -68,4 +66,3 @@ Generated from `vimrc.bundles` by `bin/generate-vim-plugin-inventory`.
 | `tpope/vim-surround` | Inactive | Add/change/delete surroundings | https://github.com/tpope/vim-surround |
 | `vim-ruby/vim-ruby` | Inactive | Ruby syntax and filetype support | https://github.com/vim-ruby/vim-ruby |
 | `vim-scripts/tComment` | Inactive | Comment toggling plugin | https://github.com/vim-scripts/tComment |
-| `williamboman/nvim-lsp-installer` | Active | Legacy LSP installer plugin | https://github.com/williamboman/nvim-lsp-installer |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Personal shell, editor, and tmux configuration with a bootstrap installer.
 - `vimrc*` and `vim/`: Vim + Neovim settings and plugin config.
 - `tmux.conf` and `.tmux/`: tmux behavior and TPM plugin setup.
 - `bin/`: utility scripts (`git-churn`, `replace`, `tat`, etc).
+- `docs/`: repository planning and decision records; it is intentionally not linked into `$HOME`.
 
 ## Requirements
 
@@ -32,7 +33,10 @@ Personal shell, editor, and tmux configuration with a bootstrap installer.
 - `zsh`
 - `git`
 - `curl`
-- `vim` or `nvim`
+- Neovim 0.12+
+- Tree-sitter CLI 0.26.1+ (`tree-sitter --version`), `tar`, and a C compiler
+- NVM with an active default Node for global editor tools
+- `typescript@5.9.3`, `typescript-language-server`, `prettier`, and `eslint` installed with npm under the active NVM default
 
 Set login shell to zsh if needed:
 
@@ -52,15 +56,19 @@ cd ~/dotfiles
 
 `install.sh` performs these steps:
 
+1. Fails before any home, plugin, or parser mutation unless `nvim` is available and reports 0.12+.
 1. Symlinks each top-level repo item to `$HOME` as a dotfile.
-1. Skips only `install.sh` and `README.md`.
+1. Skips `install.sh`, `README.md`, and the repository-only `docs/` planning directory.
 1. Warns (does not overwrite) if a destination exists and is not a symlink.
 1. Creates `~/.config/nvim/init.vim` (if missing) with `source ~/.vimrc`.
 1. Installs `vim-plug` for Neovim into:
    - `${XDG_DATA_HOME:-$HOME/.local/share}/nvim/site/autoload/plug.vim`
 1. Runs plugin install:
    - `nvim --headless -u ~/.vimrc.bundles "+PlugInstall --sync" +qa`
-   - falls back to `vim` if `nvim` is unavailable.
+1. Installs the bounded Tree-sitter parser set:
+   - `javascript`, `jsdoc`, `typescript`, and `tsx`
+
+`install.sh` does not install or upgrade Homebrew or npm packages.
 
 ## Neovim and Vim
 
@@ -77,14 +85,61 @@ Neovim compatibility is handled via `~/.config/nvim/init.vim` sourcing `~/.vimrc
 
 ### Neovim-first
 
-This config targets **Neovim**. It declares Neovim-only plugins (`nvim-lspconfig`,
-`nvim-lspinstall`, and friends), and `install.sh` bootstraps `vim-plug` only into
-Neovim's autoload path. Plain `vim` therefore errors on the `Plug` declarations and
-NERDTree never loads.
+This config targets **Neovim 0.12+**. It declares Neovim-only plugins such as
+`nvim-lspconfig`, `nvim-treesitter`, `conform.nvim`, and `nvim-lint`, and
+`install.sh` bootstraps `vim-plug` only into Neovim's autoload path. Plain `vim`
+is not a supported plugin-install fallback.
 
-To avoid that, `vim` and `vi` are aliased to `nvim` (see [`aliases`](aliases)). If you
-deliberately want plain Vim to work too, install `vim-plug` into `~/.vim/autoload/plug.vim`
-as well.
+To avoid that, `vim` and `vi` are aliased to `nvim` (see [`aliases`](aliases)).
+If you deliberately want plain Vim behavior, use it without this Neovim plugin stack.
+
+### TypeScript, TSX, JavaScript, and JSX
+
+The TypeScript editor path is external-tool first:
+
+See the [Neovim TypeScript cheatsheet](docs/NVIM_TYPESCRIPT_CHEATSHEET.md) for
+the exact mappings, save policy, health checks, and troubleshooting reference.
+
+```sh
+brew install neovim tree-sitter-cli
+nvm install 24
+nvm alias default 24
+npm install -g typescript@5.9.3 typescript-language-server prettier eslint
+```
+
+Homebrew's CLI formula is `tree-sitter-cli`; the command it installs is
+`tree-sitter`. The required command contract is `tree-sitter --version` reporting
+0.26.1 or newer.
+
+Run these checks in a login zsh so NVM's default Node is on `PATH`:
+
+```sh
+zsh -lic 'nvim --version | head -n1'
+zsh -lic 'tree-sitter --version'
+zsh -lic 'nvm --version && node --version'
+zsh -lic 'command -v typescript-language-server && typescript-language-server --version'
+zsh -lic 'tsc --version && prettier --version && eslint --version'
+zsh -lic 'nvim --headless -u ~/.vimrc +qa'
+zsh -lic 'bin/check-nvim-typescript-support'
+```
+
+`ts_ls` launches `typescript-language-server --stdio`. A raw `tsserver` binary is
+not an LSP server and is not enough for Neovim semantic support. The global
+fallback is pinned to TypeScript 5.9.3 because npm's TypeScript 7 package does not
+ship `lib/tsserver.js` and is rejected by `typescript-language-server` 5.3.0.
+Project-local TypeScript, Prettier, and ESLint are preferred when present. Global
+Prettier and ESLint are explicit fallbacks only; save-time formatting and linting
+require project-local tools.
+
+On the supported Macs, use the same login-shell flow:
+
+```sh
+NO_AUTO_TMUX=1 ssh andrewsolomon@andrews-mac-mini-1 'cd ~/dotfiles && zsh -lic "bin/check-nvim-typescript-support"'
+NO_AUTO_TMUX=1 ssh andrewsolomon@qianas-macbook-pro-1 'cd ~/dotfiles && zsh -lic "bin/check-nvim-typescript-support"'
+```
+
+Do not run the remote command until you intend to verify that machine; these checks
+read editor state and may install parsers only through `./install.sh`.
 
 ### Leader key
 
@@ -120,6 +175,9 @@ nvim --headless -u ~/.vimrc.bundles "+PlugClean!" +qa
 - `itchyny/lightline.vim`
 - `github/copilot.vim`
 - `neovim/nvim-lspconfig`
+- `nvim-treesitter/nvim-treesitter`
+- `stevearc/conform.nvim`
+- `mfussenegger/nvim-lint`
 
 ## Key mappings and usage
 
@@ -324,6 +382,35 @@ This repo also has a fallback in [`vimrc.plugins`](vimrc.plugins):
 ```vim
 :source ~/.vimrc
 ```
+
+### TypeScript LSP does not attach
+
+- Confirm Neovim is 0.12+ and `typescript-language-server` is on Neovim's `PATH`:
+  `zsh -lic 'nvim --version | head -n1; command -v typescript-language-server'`.
+- Open a file under a pinned `ts_ls` root: the nearest package-manager
+  lockfile or `.git` directory, with Neovim's process cwd as the fallback. Then
+  run `:LspInfo`.
+- `:checkhealth vim.lsp` reports Neovim LSP health. `:LspTypescriptSourceAction`
+  and `:LspTypescriptGoToSourceDefinition` are only useful after `ts_ls` attaches.
+
+### Tree-sitter parsers are missing
+
+Run:
+
+```sh
+zsh -lic 'tree-sitter --version'
+zsh -lic 'nvim --headless -u ~/.vimrc.bundles "+lua require(\"nvim-treesitter\").install({\"javascript\",\"jsdoc\",\"typescript\",\"tsx\"}):wait(300000)" +qa'
+```
+
+### Prettier or ESLint does not run automatically
+
+- Save-time Prettier requires a project-local executable at
+  `node_modules/.bin/prettier`.
+- Save-time ESLint requires both `node_modules/.bin/eslint` and a discoverable
+  `eslint.config.*`, `.eslintrc*`, or `package.json` `eslintConfig`.
+- `,fm` may fall back to global `prettier`; `,ll` may fall back to global `eslint`
+  or report that local ESLint has no config.
+- In untrusted checkouts, run `:DotfilesTypeScriptLintDisable` before saving.
 
 ### tmux keybindings not applying
 

--- a/bin/check-nvim-typescript-support
+++ b/bin/check-nvim-typescript-support
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIN_NVIM="0.12.0"
+MIN_TREE_SITTER="0.26.1"
+EXPECTED_TYPESCRIPT="5.9.3"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok: %s\n' "$*"
+}
+
+version_ge() {
+  awk -v have="$1" -v need="$2" '
+    BEGIN {
+      split(have, h, ".")
+      split(need, n, ".")
+      for (i = 1; i <= 3; i++) {
+        hv = h[i] + 0
+        nv = n[i] + 0
+        if (hv > nv) exit 0
+        if (hv < nv) exit 1
+      }
+      exit 0
+    }
+  '
+}
+
+command -v nvim >/dev/null 2>&1 || fail "nvim is required"
+command -v tree-sitter >/dev/null 2>&1 || fail "tree-sitter CLI is required; install Homebrew formula tree-sitter-cli"
+command -v typescript-language-server >/dev/null 2>&1 || fail "typescript-language-server is required on PATH"
+command -v tsc >/dev/null 2>&1 || fail "typescript is required on PATH"
+command -v prettier >/dev/null 2>&1 || fail "prettier is required on PATH for explicit fallback verification"
+command -v eslint >/dev/null 2>&1 || fail "eslint is required on PATH for explicit fallback verification"
+command -v git >/dev/null 2>&1 || fail "git is required for pinned Neovim plugin verification"
+
+nvim_version="$(nvim --version | awk 'NR == 1 { sub(/^NVIM v/, "", $2); sub(/-.*/, "", $2); print $2 }')"
+version_ge "$nvim_version" "$MIN_NVIM" || fail "nvim $MIN_NVIM+ required; found $nvim_version"
+pass "nvim $nvim_version"
+
+tree_sitter_version="$(tree-sitter --version | awk '{ print $2 }')"
+version_ge "$tree_sitter_version" "$MIN_TREE_SITTER" || fail "tree-sitter $MIN_TREE_SITTER+ required; found $tree_sitter_version"
+pass "tree-sitter $tree_sitter_version"
+
+pass "typescript-language-server $(typescript-language-server --version)"
+typescript_version="$(tsc --version | awk '{ print $2 }')"
+[[ "$typescript_version" == "$EXPECTED_TYPESCRIPT" ]] || fail "global TypeScript $EXPECTED_TYPESCRIPT required for the tested tsserver fallback; found $typescript_version"
+pass "typescript $typescript_version"
+pass "prettier $(prettier --version)"
+pass "eslint $(eslint --version)"
+
+for plugin in nvim-lspconfig nvim-treesitter conform.nvim nvim-lint; do
+  case "$plugin" in
+    nvim-lspconfig) expected_head="cb5bc0b2b35a6d513e3298d285db81453e791f4f" ;;
+    nvim-treesitter) expected_head="4916d6592ede8c07973490d9322f187e07dfefac" ;;
+    conform.nvim) expected_head="619363c30309d29ffa631e67c8183f2a72caa373" ;;
+    nvim-lint) expected_head="606b823a57b027502a9ae00978ebf4f5d5158098" ;;
+  esac
+  plugin_dir="$HOME/.vim/bundle/$plugin"
+  [[ -d "$plugin_dir/.git" ]] || fail "$plugin is not installed at $plugin_dir"
+  plugin_head="$(git -C "$plugin_dir" rev-parse HEAD 2>/dev/null)" || fail "could not read $plugin HEAD at $plugin_dir"
+  [[ "$plugin_head" == "$expected_head" ]] || fail "$plugin HEAD mismatch: expected $expected_head, found $plugin_head"
+  pass "$plugin pinned at $plugin_head"
+done
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/nvim-ts-check.XXXXXX")"
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+mkdir -p "$tmpdir/state"
+
+parser_result="$tmpdir/parser-result.txt"
+parser_error="$tmpdir/parser-error.txt"
+if ! XDG_STATE_HOME="$tmpdir/state" NVIM_TS_CHECK_PARSERS="$parser_result" nvim --headless --cmd 'set shadafile=NONE' -u "$HOME/.vimrc.bundles" \
+  "+lua local ok, ts = pcall(require, 'nvim-treesitter'); if not ok then error(ts) end; local installed = {}; for _, lang in ipairs(ts.get_installed()) do installed[lang] = true end; local missing = {}; for _, lang in ipairs({'javascript', 'jsdoc', 'typescript', 'tsx'}) do if not installed[lang] then table.insert(missing, lang) end end; if #missing > 0 then error('missing Tree-sitter parsers: ' .. table.concat(missing, ', ')) end; vim.fn.writefile({'ok'}, vim.env.NVIM_TS_CHECK_PARSERS)" +qa \
+  >/dev/null 2>"$parser_error"; then
+  fail "Tree-sitter parser check failed: $(tr '\n' ' ' < "$parser_error")"
+fi
+grep -q '^ok$' "$parser_result" || fail "Tree-sitter parser check did not report ok"
+pass "Tree-sitter parsers javascript/jsdoc/typescript/tsx installed"
+
+mkdir -p "$tmpdir/src"
+global_node_modules="$(npm root -g 2>/dev/null || true)"
+typescript_source=""
+if [[ -n "$global_node_modules" && -f "$global_node_modules/typescript/lib/tsserver.js" ]]; then
+  typescript_source="$global_node_modules/typescript"
+elif [[ -f "$ROOT_DIR/node_modules/typescript/lib/tsserver.js" ]]; then
+  typescript_source="$ROOT_DIR/node_modules/typescript"
+fi
+if [[ -n "$typescript_source" ]]; then
+  mkdir -p "$tmpdir/node_modules"
+  cp -R "$typescript_source" "$tmpdir/node_modules/typescript"
+fi
+cat > "$tmpdir/package.json" <<'JSON'
+{
+  "name": "nvim-ts-check",
+  "private": true,
+  "type": "module"
+}
+JSON
+cat > "$tmpdir/tsconfig.json" <<'JSON'
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "strict": true,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "include": ["src"]
+}
+JSON
+cat > "$tmpdir/src/index.ts" <<'TS'
+export const value: number = "wrong";
+export function greet(name: string) {
+  return name.toUpperCase();
+}
+greet("world");
+TS
+cat > "$tmpdir/src/component.tsx" <<'TSX'
+type Props = { label: string };
+export function Component(props: Props) {
+  return <button>{props.label}</button>;
+}
+TSX
+cat > "$tmpdir/src/plain.js" <<'JS'
+export const plain = { answer: 42 };
+plain.answer;
+JS
+cat > "$tmpdir/src/view.jsx" <<'JSX'
+export function View() {
+  return <main>ok</main>;
+}
+JSX
+
+lua_check="$tmpdir/check.lua"
+result_file="$tmpdir/result.txt"
+cat > "$lua_check" <<'LUA'
+local result_file = vim.env.NVIM_TS_CHECK_RESULT
+
+local function finish(ok, message)
+  if result_file and result_file ~= '' then
+    vim.fn.writefile({ ok and 'ok' or message }, result_file)
+  end
+  if ok then
+    vim.cmd('qa')
+  else
+    vim.cmd('cquit')
+  end
+end
+
+local ok, err = xpcall(function()
+local expected = {
+  ['index.ts'] = 'typescript',
+  ['component.tsx'] = 'typescriptreact',
+  ['plain.js'] = 'javascript',
+  ['view.jsx'] = 'javascriptreact',
+}
+
+local function die(msg)
+  error(msg, 0)
+end
+
+local function assert_true(value, msg)
+  if not value then
+    die(msg)
+  end
+end
+
+local function wait_for(label, predicate)
+  local ok = vim.wait(20000, predicate, 100)
+  assert_true(ok, 'timed out waiting for ' .. label)
+end
+
+assert_true(vim.fn.exists(':Copilot') == 2, 'Copilot command did not load')
+assert_true(vim.fn.exists('*copilot#Accept') == 1, 'copilot#Accept() did not load')
+local tab_map = vim.fn.maparg('<Tab>', 'i')
+assert_true(type(tab_map) == 'string' and tab_map:match('copilot#Accept'), 'insert Tab is not mapped through copilot#Accept()')
+
+local root = vim.fn.getcwd()
+for file, ft in pairs(expected) do
+  local path = root .. '/src/' .. file
+  vim.cmd.edit(vim.fn.fnameescape(path))
+  local bufnr = vim.api.nvim_get_current_buf()
+  wait_for(file .. ' filetype', function()
+    return vim.bo[bufnr].filetype == ft
+  end)
+  assert_true(vim.bo[bufnr].filetype == ft, file .. ' filetype mismatch')
+  wait_for(file .. ' Tree-sitter highlighter', function()
+    return vim.treesitter.highlighter.active[bufnr] ~= nil
+  end)
+  wait_for(file .. ' ts_ls client', function()
+    return #vim.lsp.get_clients({ bufnr = bufnr, name = 'ts_ls' }) == 1
+  end)
+  local client = vim.lsp.get_clients({ bufnr = bufnr, name = 'ts_ls' })[1]
+  assert_true(client ~= nil, file .. ' missing ts_ls client')
+  assert_true(client:supports_method('textDocument/completion'), file .. ' client lacks completion')
+  local cmd = table.concat(client.config.cmd or {}, ' ')
+  assert_true(cmd:match('typescript%-language%-server') and cmd:match('%-%-stdio'), 'ts_ls command mismatch: ' .. cmd)
+end
+
+vim.cmd.edit(vim.fn.fnameescape(root .. '/src/index.ts'))
+local tsbuf = vim.api.nvim_get_current_buf()
+wait_for('TypeScript diagnostic', function()
+  return #vim.diagnostic.get(tsbuf, { severity = vim.diagnostic.severity.ERROR }) > 0
+end)
+
+vim.cmd.edit(vim.fn.fnameescape(root .. '/src/component.tsx'))
+local tsxbuf = vim.api.nvim_get_current_buf()
+assert_true(not vim.lsp.inlay_hint.is_enabled({ bufnr = tsxbuf }), 'inlay hints should start disabled')
+vim.lsp.inlay_hint.enable(true, { bufnr = tsxbuf })
+assert_true(vim.lsp.inlay_hint.is_enabled({ bufnr = tsxbuf }), 'inlay hints did not enable')
+vim.lsp.inlay_hint.enable(false, { bufnr = tsxbuf })
+assert_true(not vim.lsp.inlay_hint.is_enabled({ bufnr = tsxbuf }), 'inlay hints did not disable')
+end, function(message)
+  return message
+end)
+
+finish(ok, err)
+LUA
+
+(
+  cd "$tmpdir"
+  XDG_STATE_HOME="$tmpdir/state" NVIM_TS_CHECK_RESULT="$result_file" nvim --headless --cmd 'set shadafile=NONE' -u "$HOME/.vimrc" "+luafile $lua_check"
+) || fail "headless Neovim TypeScript smoke check failed: $(test -f "$result_file" && cat "$result_file" || printf 'no Lua result written')"
+grep -q '^ok$' "$result_file" || fail "$(cat "$result_file")"
+pass "headless TS/TSX/JS/JSX smoke check"
+
+copilot_status="$tmpdir/copilot-status.txt"
+copilot_check="$tmpdir/copilot-check.lua"
+cat > "$copilot_check" <<'LUA'
+local status_file = vim.env.NVIM_TS_CHECK_COPILOT_STATUS
+local function finish(ok, message)
+  vim.fn.writefile({ message }, status_file)
+  if ok then
+    vim.cmd('qa')
+  else
+    vim.cmd('cquit')
+  end
+end
+
+local ok, err = xpcall(function()
+  local root = vim.fn.getcwd()
+  vim.cmd.edit(vim.fn.fnameescape(root .. '/src/index.ts'))
+  vim.fn['copilot#Init']()
+  local ready = vim.wait(20000, function()
+    local client = vim.fn['copilot#RunningClient']()
+    return type(client) == 'table' and client.serverInfo ~= nil
+  end, 100)
+  if not ready then
+    error('Copilot language server did not initialize within 20s for src/index.ts', 0)
+  end
+  local status = vim.fn.execute('Copilot status')
+  if not status:match('Ready') then
+    error('Copilot status was not Ready: ' .. status:gsub('\n', ' '), 0)
+  end
+end, function(message)
+  return message
+end)
+
+finish(ok, ok and 'ok' or err)
+LUA
+(
+  cd "$tmpdir"
+  XDG_STATE_HOME="$tmpdir/state" NVIM_TS_CHECK_COPILOT_STATUS="$copilot_status" nvim --headless --cmd 'set shadafile=NONE' -u "$HOME/.vimrc" "+luafile $copilot_check"
+) >/dev/null 2>&1 || fail "Copilot status check failed: $(test -f "$copilot_status" && tr '\n' ' ' < "$copilot_status" || printf 'no Lua result written')"
+grep -q '^ok$' "$copilot_status" || fail "$(cat "$copilot_status")"
+pass "Copilot Ready"
+
+printf 'PASS: Neovim TypeScript support checks passed\n'

--- a/bin/generate-vim-plugin-inventory
+++ b/bin/generate-vim-plugin-inventory
@@ -70,6 +70,8 @@ awk '
     d["kabouzeid/nvim-lspinstall"] = "Legacy Neovim LSP installer"
     d["neovim/nvim-lsp"] = "Legacy Neovim LSP plugin"
     d["williamboman/nvim-lsp-installer"] = "Legacy LSP installer plugin"
+    d["stevearc/conform.nvim"] = "Lightweight formatter integration for Neovim"
+    d["mfussenegger/nvim-lint"] = "Asynchronous linting through external linters"
     d["github/copilot.vim"] = "GitHub Copilot integration"
     d["nvim-lua/plenary.nvim"] = "Lua utility library used by Neovim plugins"
     d["nvim-telescope/telescope.nvim"] = "Fuzzy finder and picker UI"

--- a/docs/NVIM_TYPESCRIPT_CHEATSHEET.md
+++ b/docs/NVIM_TYPESCRIPT_CHEATSHEET.md
@@ -1,0 +1,168 @@
+# Neovim TypeScript, TSX, JavaScript, and JSX Cheatsheet
+
+Practical reference for the configuration in this repository. The leader key is
+`,`; semantic actions require an attached `ts_ls` client. This file stays in the
+repository-only `docs/` directory and is not linked into `$HOME`
+([ADR 0019](decisions/0019-do-not-symlink-repository-docs-to-home.md)).
+
+## Prerequisites and health
+
+- Neovim 0.12+ and Tree-sitter CLI 0.26.1+.
+- The `javascript`, `jsdoc`, `typescript`, and `tsx` Tree-sitter parsers.
+- NVM default Node 24 with global `typescript@5.9.3`,
+  `typescript-language-server`, `prettier`, and `eslint` on `PATH`.
+- The pinned `nvim-lspconfig`, `nvim-treesitter`, `conform.nvim`, and
+  `nvim-lint` plugins, plus `github/copilot.vim` when using Copilot.
+
+Run checks from the repository root in a login zsh so the NVM default is active:
+
+```sh
+zsh -lic 'nvim --version | head -n1'
+zsh -lic 'tree-sitter --version'
+zsh -lic 'command -v typescript-language-server && typescript-language-server --version'
+zsh -lic 'tsc --version && prettier --version && eslint --version'
+zsh -lic 'nvim --headless -u ~/.vimrc +qa'
+zsh -lic 'bin/check-nvim-typescript-support'
+```
+
+Inside Neovim, use `:LspInfo` for attachment and `:checkhealth vim.lsp` for LSP
+health. `ts_ls` must show one client launched as
+`typescript-language-server --stdio`; raw `tsserver` is not an LSP server.
+
+## Supported files
+
+| Extension | Neovim filetype | Tree-sitter language |
+|-----------|-----------------|----------------------|
+| `.ts` | `typescript` | `typescript` |
+| `.tsx` | `typescriptreact` | `tsx` |
+| `.js` | `javascript` | `javascript` |
+| `.jsx` | `javascriptreact` | `javascript` |
+
+The stack targets standard Node/browser JavaScript and TypeScript plus
+React-style JSX/TSX. Deno and framework-specific Vue, Svelte, Astro, and Angular
+language-server integration are outside this configuration.
+
+## LSP navigation and refactoring
+
+`gd`, `K`, diagnostic navigation, formatting, linting, and inlay hints are set
+buffer-locally on LSP attachment. The `gr*`, `gO`, and insert-mode `Ctrl+S`
+mappings below are Neovim 0.12 native LSP defaults.
+
+| Key | Action |
+|-----|--------|
+| `gd` | Go to definition |
+| `K` | Show hover; without an attached LSP it keeps this config's global grep action |
+| `grr` | List references |
+| `gri` | Go to implementation |
+| `grt` | Go to type definition |
+| `grn` | Rename symbol |
+| `gra` | Show code actions in normal or visual mode |
+| `gO` | List document symbols |
+| `Ctrl+S` (insert) | Show signature help |
+| `Ctrl+O` / `Ctrl+I` | Move backward / forward through the jump list |
+
+## Completion and Copilot
+
+Native LSP completion is enabled with auto-triggering when the attached client
+supports completion. The menu uses `menu`, `menuone`, `noselect`, and `popup`.
+
+| Key / command | Action |
+|---------------|--------|
+| `Ctrl+N` / `Ctrl+P` | Select the next / previous completion candidate |
+| `Ctrl+Y` | Accept the selected native completion candidate |
+| `Tab` | Accept the current Copilot inline suggestion |
+| `:Copilot status` | Check Copilot readiness without changing authentication |
+
+LSP completion does not remap `Tab`. A visible completion menu can temporarily
+hide a Copilot inline suggestion, so choose native candidates with
+`Ctrl+N`/`Ctrl+P`/`Ctrl+Y` and use `Tab` separately for Copilot.
+
+## Diagnostics and inlay hints
+
+TypeScript LSP and ESLint diagnostics use separate namespaces but share the
+same presentation: severity-sorted ASCII `E`/`W`/`I`/`H` signs, underlines for
+errors and warnings, inline virtual text for errors only, and rounded detail
+floats that show a source when multiple sources contribute.
+
+| Key | Action |
+|-----|--------|
+| `[d` | Previous diagnostic and open its float |
+| `]d` | Next diagnostic and open its float |
+| `,ih` | Toggle configured inlay hints for the current buffer |
+
+Inlay hints start disabled. The toggle affects only the current buffer and
+covers parameter names, inferred types, return types, properties, and enum
+values supplied by `ts_ls`.
+
+## Explicit TypeScript actions
+
+| Key / command | Action |
+|---------------|--------|
+| `gra` | Contextual code actions and refactors at the cursor or visual selection |
+| `:LspTypescriptSourceAction` | Whole-file `source.*` actions such as organize imports or remove unused code |
+| `:LspTypescriptGoToSourceDefinition` | Jump to original source instead of a type definition |
+
+The two commands are buffer-local and exist only after `ts_ls` attaches. Saving
+never runs organize-imports, fix-all, or another TypeScript source action.
+
+## Prettier and ESLint policy
+
+| Action | Project-local behavior | Global fallback |
+|--------|------------------------|-----------------|
+| Save (format) | Format only if an executable `node_modules/.bin/prettier` is found upward | Never |
+| `,fm` | Format with the nearest local Prettier; `:ConformInfo` shows resolution | Allowed when no local Prettier exists |
+| Save (lint) | Lint after save only if local ESLint and a discoverable config are both found upward | Never |
+| `,ll` | Lint with configured local ESLint | Allowed only when no local ESLint exists |
+
+Prettier save opt-in is the local executable itself; no Prettier config is
+required. Both automatic and explicit formatting set `lsp_format = 'never'`.
+
+ESLint config discovery recognizes `eslint.config.{js,mjs,cjs,ts,mts,cts}`,
+`.eslintrc`, `.eslintrc.{js,cjs,yaml,yml,json}`, and a `package.json`
+`eslintConfig` key. If a local ESLint exists without a config, saves stay quiet
+and `,ll` reports the missing config; it does not bypass that local binary with
+global ESLint. Use
+`:DotfilesTypeScriptLintDisable` to disable automatic ESLint for the current
+buffer (useful before saving an untrusted checkout). Explicit `,ll` remains
+available.
+
+## Troubleshooting
+
+- Wrong language mode: run `:set filetype?` and compare it with the table above.
+- No semantics or TypeScript commands: run `:LspInfo` and
+  `:checkhealth vim.lsp`. Open the file below the nearest package-manager
+  lockfile or `.git`; otherwise `ts_ls` uses Neovim's working directory. A nearer
+  Deno root intentionally prevents attachment.
+- Server not executable: launch Neovim from a login zsh and check
+  `command -v typescript-language-server`; installing only `tsserver` is
+  insufficient.
+- Missing or stale parsing: run the repository checker; it verifies all four
+  required Tree-sitter parsers and active highlighting for all four filetypes.
+- Formatting surprises: run `:ConformInfo`. Save requires a local executable;
+  `,fm` may deliberately use global Prettier.
+- Missing ESLint diagnostics: save-time lint needs both a local executable and
+  config. Run `,ll` for explicit feedback. Disabling automatic lint also clears
+  the current buffer's ESLint diagnostics, not its `ts_ls` diagnostics.
+- `K` greps instead of showing hover: no LSP buffer-local mapping has attached;
+  confirm with `:LspInfo`.
+- Copilot is absent: run `:Copilot status`; do not use setup or sign-out as a
+  health check.
+
+## Verification checklist for both Macs
+
+Repeat this checklist locally on `andrews-mac-mini-1` and
+`qianas-macbook-pro-1`:
+
+1. From `~/dotfiles`, run
+   `zsh -lic 'bin/check-nvim-typescript-support'` and require the final `PASS`.
+2. Open representative `.ts` and `.tsx` project files; confirm their filetypes,
+   Tree-sitter highlighting, and exactly one `ts_ls` in `:LspInfo`. Spot-check
+   `.js` and `.jsx` attachment too.
+3. Exercise `gd`, `K`, `grr`, `gri`, `grt`, `grn`, `gra`, `[d`/`]d`, both
+   TypeScript commands, and the `,ih` off/on/off cycle.
+4. Confirm LSP completion with `Ctrl+N`/`Ctrl+P`/`Ctrl+Y`, then separately check
+   `:Copilot status` and accept an inline suggestion with `Tab`.
+5. Confirm local Prettier formats via save and `,fm`; confirm configured local
+   ESLint publishes and clears diagnostics after saves. Verify global-only tools
+   run only through the explicit mappings and an ordinary save performs no
+   source actions.

--- a/docs/decisions/0001-require-neovim-0.12-for-typescript-support.md
+++ b/docs/decisions/0001-require-neovim-0.12-for-typescript-support.md
@@ -1,0 +1,22 @@
+# ADR 0001: Require Neovim 0.12 for TypeScript support
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+The current machine has Neovim 0.11.1. The installed `nvim-lspconfig` documentation requires Neovim 0.11.3 or newer, while the current `nvim-treesitter` `main` branch requires Neovim 0.12 or newer and Tree-sitter CLI 0.26.1 or newer. Homebrew currently offers Neovim 0.12.4.
+
+Supporting current LSP and Tree-sitter APIs on one baseline is simpler and safer than pinning a legacy Tree-sitter branch or deferring TSX parsing.
+
+## Decision
+
+Require Neovim 0.12 or newer for this TypeScript-support effort. Use the current `nvim-treesitter` `main` API and require Tree-sitter CLI 0.26.1 or newer.
+
+## Consequences
+
+- The local Neovim and Tree-sitter CLI must be upgraded before implementation validation.
+- The implementation may use `vim.lsp.enable`, native LSP completion, and the current Tree-sitter installation/highlighting APIs.
+- Neovim 0.11 and the legacy `nvim-treesitter` `master` API are out of scope.
+- README setup and smoke checks must enforce and explain the minimum versions.

--- a/docs/decisions/0002-provision-typescript-tools-outside-neovim.md
+++ b/docs/decisions/0002-provision-typescript-tools-outside-neovim.md
@@ -1,0 +1,28 @@
+# ADR 0002: Provision TypeScript tools outside Neovim
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+The dotfiles are used on two Tailscale-connected Macs:
+
+- `andrews-mac-mini-1` — current Mac mini.
+- `qianas-macbook-pro-1` — remote MacBook Pro.
+
+The existing Neovim configuration declares several obsolete LSP installer plugins. A modern installer such as Mason could replace them, but it would add another package-management layer inside Neovim. Both machines already use Homebrew and share these dotfiles through Git.
+
+## Decision
+
+Remove the obsolete Neovim LSP installers without replacing them with Mason. Provision Neovim and Tree-sitter CLI through Homebrew formulas `neovim` and `tree-sitter-cli` on each machine. Per [ADR 0018](0018-use-nvm-for-node-based-editor-tools.md), install global TypeScript 5.9.3, `typescript-language-server`, Prettier, and ESLint through npm under the active NVM default on both machines. Continue to prefer project-local TypeScript, Prettier, and ESLint versions when present.
+
+Document equivalent, architecture-neutral setup and verification commands for both Macs. The Mac mini uses Apple Silicon Homebrew under `/opt/homebrew`; the MacBook Pro is Intel and uses Homebrew under `/usr/local`, so scripts must resolve native tools through `command -v`/`brew --prefix` rather than hard-code either prefix. All Node-based checks must load and report the active NVM default; remote headless checks especially require the MacBook's interactive zsh/NVM environment because its non-interactive `/usr/local/bin/node` is currently broken. Do not SSH to or mutate the other machine unless the user explicitly authorizes that operation.
+
+## Consequences
+
+- Neovim configuration remains smaller and does not own system executables.
+- Each Mac requires a one-time external tool installation and independent verification.
+- Version and architecture drift between machines is real, so the smoke checker must validate minimum versions, active-shell PATH, Node health, and required executables without assuming a Homebrew prefix.
+- `install.sh` may install/update Vim plugins and Tree-sitter parsers, but it must not install global Homebrew/npm packages.
+- Missing optional Prettier or ESLint tools must degrade gracefully; missing `typescript-language-server` must be reported clearly because semantic TypeScript support depends on it.

--- a/docs/decisions/0003-support-javascript-alongside-typescript.md
+++ b/docs/decisions/0003-support-javascript-alongside-typescript.md
@@ -1,0 +1,30 @@
+# ADR 0003: Support JavaScript alongside TypeScript
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+The primary goal is modern TypeScript and TSX editing. The standard `nvim-lspconfig` `ts_ls` configuration also supports JavaScript and JSX through the `javascript` and `javascriptreact` filetypes. Mixed JavaScript/TypeScript projects are common, and restricting the language server would require overriding upstream defaults.
+
+Tree-sitter, Prettier, and ESLint also naturally cover all four JS/TS filetypes.
+
+## Decision
+
+Treat TypeScript and TSX as the primary acceptance target, while enabling the same LSP, parser, formatting, and linting stack for JavaScript and JSX.
+
+The supported filetypes are:
+
+- `typescript`
+- `typescriptreact`
+- `javascript`
+- `javascriptreact`
+
+## Consequences
+
+- Mixed JS/TS repositories receive one coherent editing experience.
+- The implementation can retain the standard `ts_ls` filetype list instead of maintaining a custom restriction.
+- Smoke coverage must verify attachment/filetype behavior across all four filetypes, while deeper semantic/refactor acceptance remains focused on TS and TSX.
+- Documentation must say that JavaScript/JSX support is intentional, not accidental scope creep.
+- Existing JavaScript behavior may change, so regression QA must cover representative `.js` and `.jsx` buffers.

--- a/docs/decisions/0004-use-ts-ls-language-server.md
+++ b/docs/decisions/0004-use-ts-ls-language-server.md
@@ -1,0 +1,27 @@
+# ADR 0004: Use `ts_ls` as the TypeScript language server
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+The editor needs one semantic engine for TypeScript, TSX, JavaScript, and JSX. The main candidates were:
+
+- `ts_ls` through `typescript-language-server`.
+- `vtsls`, which builds on VS Code's TypeScript extension behavior.
+- `typescript-tools.nvim`, a TypeScript-specific Neovim plugin that communicates with `tsserver`.
+
+The requested capabilities are diagnostics, completion, navigation, rename/refactoring, import/source actions, and project-aware TypeScript behavior. The current `nvim-lspconfig` `ts_ls` configuration provides these capabilities, monorepo/root handling, Deno exclusion, TypeScript source-action commands, and project-local TypeScript discovery without another Neovim plugin.
+
+## Decision
+
+Use only `ts_ls`, launched as `typescript-language-server --stdio`. Do not enable `vtsls`, `typescript-tools.nvim`, or raw `tsserver` as another client.
+
+## Consequences
+
+- The configuration follows the standard current `nvim-lspconfig` path.
+- `typescript-language-server` is a required external executable on both supported Macs.
+- Project-local TypeScript remains preferred by the server.
+- Verification must prove exactly one `ts_ls` client attaches per supported buffer.
+- Richer server-specific features unique to `vtsls` or `typescript-tools.nvim` are deferred and may be reconsidered only if a concrete missing workflow appears.

--- a/docs/decisions/0005-use-native-lsp-completion-and-preserve-copilot.md
+++ b/docs/decisions/0005-use-native-lsp-completion-and-preserve-copilot.md
@@ -1,0 +1,32 @@
+# ADR 0005: Use native LSP completion and preserve Copilot
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+Neovim 0.12 provides native LSP completion through `vim.lsp.completion`. The alternatives were adding an `nvim-cmp` stack or retaining manual omnifunc completion.
+
+`github/copilot.vim` is already active and uses insert-mode `Tab` to accept inline suggestions. Its documentation states that `:Copilot status` checks operational status and that existing completion-menu visibility can temporarily hide inline suggestions.
+
+A read-only baseline check on 2026-07-14 found:
+
+- The `:Copilot` command exists.
+- Insert-mode `Tab` maps to `copilot#Accept()`.
+- `copilot#Accept` exists.
+- Headless `:Copilot status` reports `Copilot: Ready` in a TypeScript buffer.
+
+## Decision
+
+Use Neovim native LSP completion with auto-triggering. Navigate LSP candidates with `Ctrl-N`/`Ctrl-P` and accept with `Ctrl-Y`. Do not map `Tab`; preserve Copilot's `Tab` acceptance behavior.
+
+Treat Copilot health and coexistence as explicit acceptance criteria. Headless tests must verify plugin loading, status, and mappings; an interactive test must verify an inline suggestion can actually render and be accepted because headless mode cannot prove UI behavior.
+
+## Consequences
+
+- No `nvim-cmp` or completion-source plugins are added.
+- The stale TypeScript omnifunc is removed after LSP completion works.
+- The smoke checker must assert the Copilot command/function and `Tab` mapping, and run non-mutating `:Copilot status`.
+- Automation must never run `:Copilot setup`, sign out, or expose authentication data.
+- Native completion and Copilot need separate acceptance paths so one cannot mask a regression in the other.

--- a/docs/decisions/0006-format-on-save-with-project-local-prettier.md
+++ b/docs/decisions/0006-format-on-save-with-project-local-prettier.md
@@ -1,0 +1,30 @@
+# ADR 0006: Format on save only with project-local Prettier
+
+- **Status:** Accepted; local-binary criterion explicitly confirmed
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+Formatting should feel automatic in projects that have deliberately installed Prettier, without imposing a global formatter or default style on every JavaScript/TypeScript file.
+
+The choices were explicit-only formatting, project-aware format-on-save, or format-on-save using any local/global Prettier. Conform's command resolver can search upward from the current buffer for `node_modules/.bin/prettier` and can expose an explicit format action separately. Its built-in Prettier `cwd`, however, is config-driven and does not treat an ordinary package root/local binary as sufficient, so the confirmed binary-only policy requires a custom `cwd` resolver.
+
+## Decision
+
+For JavaScript, JSX, TypeScript, and TSX buffers:
+
+- Format on save whenever an executable `node_modules/.bin/prettier` is found by searching upward from that buffer's directory.
+- The binary alone is the opt-in signal. A direct Prettier dependency, `.prettierrc`, `prettier.config.*`, or `package.json` Prettier key is not additionally required.
+- Never fall back to global Prettier or `ts_ls` during format-on-save.
+- Keep `<leader>fm` as an explicit format action. The explicit action may use project-local Prettier first and global `prettier` as fallback.
+- Override Conform's Prettier `cwd`: derive the owning project root from the nearest local binary path; when explicit formatting uses only global Prettier, use the buffer directory. Prettier's `--stdin-filepath` continues to resolve any applicable config from the file path.
+
+## Consequences
+
+- Projects with a discoverable local Prettier binary receive automatic formatting, including binaries made available through a workspace or transitive installation.
+- Projects without local Prettier are never changed automatically.
+- A global Prettier remains useful for deliberate one-off formatting but cannot silently rewrite files on save.
+- The implementation needs separate formatter-availability logic for automatic and explicit formatting plus a custom `cwd` resolver aligned with the nearest executable.
+- A transitive/workspace-provided Prettier version can change without a direct dependency update; `:ConformInfo` and QA must report the executable/version actually selected.
+- Tests must cover local-Prettier save, nearest executable/owning-root resolution in a nested monorepo, global-only save, no-Prettier save, and explicit global fallback.

--- a/docs/decisions/0007-lint-on-save-with-project-local-eslint.md
+++ b/docs/decisions/0007-lint-on-save-with-project-local-eslint.md
@@ -1,0 +1,31 @@
+# ADR 0007: Lint on save only with project-local ESLint
+
+- **Status:** Accepted; config-presence criterion explicitly confirmed
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+ESLint versions and configuration formats vary by project. Automatically running a global ESLint can produce version/configuration mismatches or execute against projects that did not opt into ESLint. Automatically running project-local binaries also requires trusting the repository.
+
+The choices were local-only linting after save, automatic global fallback, or more frequent linting during editing.
+
+## Decision
+
+For JavaScript, JSX, TypeScript, and TSX buffers:
+
+- Run ESLint automatically after save only when both conditions are true:
+  1. An executable `node_modules/.bin/eslint` is found upward from the buffer directory.
+  2. A discoverable flat/legacy ESLint config exists upward from the buffer, including `eslint.config.*`, `.eslintrc*`, or a `package.json` `eslintConfig` key.
+- Do not use global ESLint automatically, and do not attempt automatic linting when configuration is absent.
+- Provide a documented explicit lint command/mapping that prefers project-local ESLint and may fall back to global `eslint`.
+- Run automatic project-local linting only in trusted repositories and document a per-buffer/project disable path.
+- Do not lint on `InsertLeave` in the initial implementation.
+
+## Consequences
+
+- Projects with local, configured ESLint receive save-time diagnostics using their own version.
+- Projects without local ESLint or without a discoverable config remain quiet on save.
+- Global ESLint is available only through deliberate invocation.
+- The implementation needs separate automatic and explicit linter-selection paths, analogous to formatting.
+- Tests must cover configured local-ESLint save linting, local-without-config quiet behavior, global-only no-auto behavior, explicit failure/fallback messaging, diagnostic clearing, and missing-tool behavior.

--- a/docs/decisions/0008-configure-inlay-hints-with-an-off-by-default-toggle.md
+++ b/docs/decisions/0008-configure-inlay-hints-with-an-off-by-default-toggle.md
@@ -1,0 +1,24 @@
+# ADR 0008: Configure inlay hints with an off-by-default toggle
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+TypeScript inlay hints can expose inferred parameter names, variable/property types, function parameter/return types, and enum values. They are useful for unfamiliar code but can add substantial visual noise.
+
+Neovim provides a built-in inlay-hint API (available before, and supported by, the selected 0.12+ baseline), and `typescript-language-server` can request TypeScript/JavaScript hints through server settings.
+
+## Decision
+
+Configure `ts_ls` inlay-hint preferences for all four supported JS/TS filetypes, but leave hint display disabled by default. Add a documented buffer-local toggle using Neovim's current `vim.lsp.inlay_hint` API.
+
+The toggle must enable hints only for the current buffer and accurately reflect/toggle the current state. Re-sourcing the configuration must not duplicate mappings or force hints on.
+
+## Consequences
+
+- Inlay hints are available on demand without making every buffer visually noisy.
+- The `ts_ls` settings need explicit TypeScript and JavaScript inlay-hint preferences.
+- The cheatsheet must document the toggle and its buffer-local scope.
+- Verification must confirm hints start disabled, become visible after toggling, and disappear after toggling again in both TypeScript and TSX fixtures.

--- a/docs/decisions/0009-keep-typescript-source-actions-explicit.md
+++ b/docs/decisions/0009-keep-typescript-source-actions-explicit.md
@@ -1,0 +1,24 @@
+# ADR 0009: Keep TypeScript source actions explicit
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+`ts_ls` can expose whole-file source actions such as organizing imports, adding missing imports, removing unused code, and applying TypeScript fixes. These actions may edit more code than formatting and can interact with save-time Prettier behavior.
+
+The choices were explicit actions, automatic organize-imports, or automatic organize-imports plus fix-all.
+
+## Decision
+
+Keep all TypeScript code/source actions explicit. Do not organize imports or apply TypeScript fix-all automatically on save.
+
+Expose the standard buffer-local `gra` code-action path and document `:LspTypescriptSourceAction` for whole-file TypeScript source actions. If a stable leader alias is added, it must invoke the same explicit action and must not run from a save autocmd.
+
+## Consequences
+
+- Saving can format with project-local Prettier and lint with project-local ESLint, but it never performs semantic refactors.
+- Import organization and fix-all remain deliberate, reviewable user actions.
+- Tests must verify source actions work when invoked and that ordinary saves do not add/remove/reorder imports or apply fix-all.
+- Automatic source actions may be reconsidered only as a separate decision after real-project usage.

--- a/docs/decisions/0010-use-balanced-diagnostic-presentation.md
+++ b/docs/decisions/0010-use-balanced-diagnostic-presentation.md
@@ -1,0 +1,27 @@
+# ADR 0010: Use balanced diagnostic presentation
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+TypeScript LSP and ESLint can produce many diagnostics. Showing every warning inline is noisy, while hiding all messages makes type errors harder to notice. Neovim diagnostics can independently control signs, underlines, virtual text, severity ordering, floats, and navigation.
+
+## Decision
+
+Use a balanced diagnostic display across LSP and ESLint namespaces:
+
+- Show signs and underlines for warnings and errors.
+- Show inline virtual text only for errors.
+- Sort by severity.
+- Provide a bordered diagnostic float with full details on demand.
+- Provide documented previous/next diagnostic mappings.
+- Use ASCII-safe sign text so the display does not require a Nerd Font.
+
+## Consequences
+
+- Errors remain prominent without placing every warning message inline.
+- Warnings remain visible through signs/underlines and can be inspected in the float.
+- The same presentation applies consistently to TypeScript and ESLint diagnostics.
+- Verification must cover error virtual text, warning suppression from virtual text, signs/underlines, float content, severity order, and navigation.

--- a/docs/decisions/0011-replace-legacy-typescript-syntax-with-tree-sitter.md
+++ b/docs/decisions/0011-replace-legacy-typescript-syntax-with-tree-sitter.md
@@ -1,0 +1,24 @@
+# ADR 0011: Replace legacy TypeScript syntax with Tree-sitter
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+`leafgarland/typescript-vim` currently provides TypeScript syntax/filetype support, while the TSX plugin declaration is inactive. Neovim 0.12 has native TypeScript/TSX filetype detection, and the selected current `nvim-treesitter` stack supplies parser-based highlighting for TypeScript and TSX.
+
+Keeping legacy syntax as a fallback would leave two highlighting systems and make parser failures less obvious. A conditional fallback would add configuration paths that need separate testing.
+
+## Decision
+
+After verifying native filetype detection and installed Tree-sitter parsers/highlighters for TS and TSX, remove `leafgarland/typescript-vim` and the inactive `peitalin/vim-jsx-typescript` declaration. Tree-sitter becomes the sole TS/TSX parser/highlighter.
+
+Do not run `PlugClean!` until the replacement behavior passes.
+
+## Consequences
+
+- TypeScript and TSX highlighting use one current parser system.
+- Parser installation and health checks become required rather than silently falling back.
+- `install.sh` and the smoke checker must verify all selected parsers.
+- Rollback is straightforward: restore the plugin declaration if Tree-sitter cannot be made reliable, but do not ship both paths by default.

--- a/docs/decisions/0012-use-native-first-keybindings.md
+++ b/docs/decisions/0012-use-native-first-keybindings.md
@@ -1,0 +1,34 @@
+# ADR 0012: Use native-first LSP keybindings
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+Neovim 0.12 provides a `gr*` family of built-in LSP mappings. The current cheatsheet inaccurately presents `gr` as references and `K` as hover even though the configuration globally maps `K` to grep and no server attaches.
+
+Adding a second leader-based mapping vocabulary would increase documentation and maintenance. Mapping bare `gr` would conflict with Neovim's native `grn`, `gra`, `grr`, and `gri` family.
+
+## Decision
+
+Use the native-first mapping model:
+
+- `gd` — definition (buffer-local when LSP attaches).
+- `K` — hover in an attached buffer; retain global grep behavior elsewhere.
+- `grn` — rename.
+- `gra` — code action.
+- `grr` — references.
+- `gri` — implementation.
+- `[d` / `]d` — previous/next diagnostic.
+- `<leader>fm` — explicit format.
+- `<leader>ll` — explicit lint.
+- `<leader>ih` — buffer-local inlay-hint toggle.
+- TypeScript source actions and source-definition navigation remain documented commands unless a later demonstrated workflow justifies another mapping.
+
+## Consequences
+
+- The configuration aligns with current Neovim conventions.
+- No bare `gr` mapping or redundant rename/code-action leader aliases are added.
+- README and CHEATSHEET must replace the inaccurate current mapping descriptions.
+- Headless checks must inspect buffer/global mappings, and interactive QA must exercise each mapping in the appropriate context.

--- a/docs/decisions/0013-limit-scope-to-standard-js-ts-and-react-tsx.md
+++ b/docs/decisions/0013-limit-scope-to-standard-js-ts-and-react-tsx.md
@@ -1,0 +1,22 @@
+# ADR 0013: Limit scope to standard JS/TS and React-style TSX
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+The selected `ts_ls` configuration supports standard JavaScript, TypeScript, JSX, and TSX projects. Deno requires mutually exclusive routing with `denols`; Vue, Svelte, Astro, and Angular require additional language servers and framework-specific integration.
+
+Adding those ecosystems would broaden installation, root detection, plugin configuration, and testing without evidence that they are needed for the current projects.
+
+## Decision
+
+Support standard Node/browser projects using JavaScript, TypeScript, JSX, and React-style TSX. Keep Deno and framework-specific single-file/language-server integration for Vue, Svelte, Astro, and Angular out of scope.
+
+## Consequences
+
+- The implementation retains the standard `ts_ls` Deno-exclusion behavior.
+- React-style TSX is fully in scope through the `typescriptreact` filetype.
+- No `denols`, Vue, Svelte, Astro, or Angular server/tool dependencies are added.
+- If one of these ecosystems becomes an actual requirement, it should start a separate decision/plan with its own root-routing and verification criteria.

--- a/docs/decisions/0014-validate-with-fixtures-and-real-projects-on-both-macs.md
+++ b/docs/decisions/0014-validate-with-fixtures-and-real-projects-on-both-macs.md
@@ -1,0 +1,36 @@
+# ADR 0014: Validate with fixtures and real projects on both Macs
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+The dotfiles repository does not contain a representative TypeScript application. A disposable fixture can prove filetype detection, parser activation, LSP attachment, diagnostics, completion capabilities, mappings, Copilot health, and controlled lint/format edge cases, but it cannot fully prove behavior with real project-local TypeScript, Prettier, ESLint, imports, TSX, or monorepo configuration.
+
+The dotfiles must work on both `andrews-mac-mini-1` and `qianas-macbook-pro-1`.
+
+## Decision
+
+Require two validation layers on both supported Macs:
+
+1. Run the repeatable automated disposable-fixture/headless checks.
+2. Run interactive QA in at least one real TypeScript/TSX project with project-local tooling.
+
+Representative projects:
+
+- Mac mini: `~/Documents/Github/sprtsmng`, with `apps/web` as the primary TSX/Next.js package and `apps/tui` as an additional TypeScript package.
+- MacBook Pro: `~/draft/draftMachine`, using `src/app/_components/sidenav.tsx` as an initial TSX file and `tailwind.config.ts` as an initial TS file.
+
+The Mac-mini repository is a pnpm monorepo with TS/TSX source, package-level `tsconfig.json` and ESLint flat configs, package-local TypeScript/ESLint, and a root `node_modules/.bin/prettier`. It does not currently expose a main-worktree Prettier style config or direct root Prettier dependency, but ADR 0006 explicitly treats the discovered local binary alone as the format-on-save opt-in.
+
+Read-only inspection found the MacBook currently has Neovim 0.9.5, Tree-sitter CLI 0.20.8, no global `typescript-language-server`, and an `nvim-lspconfig` startup error caused by the unsupported Neovim version. Copilot still reports ready headlessly. The project has local TypeScript 5.3.3, Prettier 3.3.3, and ESLint 8.57.1, but ESLint has no discoverable configuration and fails its stdin probe. Under ADR 0007, real-project saves must therefore skip lint quietly; publish/clear behavior must be validated in a disposable configured ESLint fixture rather than by modifying `draftMachine`. The interactive zsh/NVM Node 24.15.0 works; the non-interactive `/usr/local/bin/node` is broken because it links a missing ICU library.
+
+Remote MacBook access or mutation still requires explicit authorization at execution time.
+
+## Consequences
+
+- A passing Mac-mini check alone is insufficient for shipping.
+- Machine-specific PATH, Homebrew, Node/NVM, Copilot, parser, and project-local tool differences are exercised.
+- The progress tracker must keep MacBook verification open until it is actually completed.
+- If one machine cannot be accessed, it is reported as a shipping blocker rather than silently treated as covered.

--- a/docs/decisions/0015-use-the-macbook-nvm-environment-for-verification.md
+++ b/docs/decisions/0015-use-the-macbook-nvm-environment-for-verification.md
@@ -1,0 +1,27 @@
+# ADR 0015: Use the MacBook NVM environment for verification
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+Read-only MacBook inspection found two Node environments:
+
+- Interactive zsh loads NVM Node 24.15.0 successfully.
+- Non-interactive `/usr/local/bin/node` is broken because it links a missing ICU dylib.
+
+Copilot reports ready when Neovim runs with the interactive NVM environment. Repairing Homebrew Node/ICU would mutate machine-level tooling outside the TypeScript editor configuration, while hard-coding an NVM version path would be fragile and machine-specific.
+
+## Decision
+
+Keep Homebrew Node/ICU repair outside this effort. Run remote/headless MacBook verification through its intended login-shell environment (for example, `NO_AUTO_TMUX=1 zsh -lic '<command>'`) and report the resolved `node`, `nvim`, and related executable paths in test output.
+
+Do not hard-code an NVM version path in tracked Neovim configuration.
+
+## Consequences
+
+- Verification reflects how the user normally launches Neovim from interactive zsh.
+- Remote scripts must suppress/handle the known non-TTY `stty` warning without hiding real command failures.
+- A separate machine-maintenance task may repair `/usr/local/bin/node`, but it is not a blocker while the intended NVM environment works.
+- Tests must fail clearly if the login shell stops loading a working Node version.

--- a/docs/decisions/0016-fail-fast-on-unsupported-neovim.md
+++ b/docs/decisions/0016-fail-fast-on-unsupported-neovim.md
@@ -1,0 +1,29 @@
+# ADR 0016: Fail fast on unsupported Neovim
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+The selected current `nvim-treesitter` API requires Neovim 0.12+, and the current LSP stack also requires a newer Neovim than either machine presently has. Read-only MacBook inspection demonstrated the failure mode: `install.sh` can install/update a current `nvim-lspconfig` checkout while Neovim 0.9.5 then errors during startup.
+
+The existing installer falls back to plain Vim when Neovim is unavailable, even though the repository is explicitly Neovim-first and the selected plugins cannot provide the planned behavior in plain Vim.
+
+## Decision
+
+Before any plugin or parser installation, `install.sh` must:
+
+1. Require `nvim` to exist.
+2. Parse and require Neovim 0.12 or newer.
+3. Fail non-zero with architecture-neutral Homebrew/manual upgrade guidance when the requirement is not met.
+4. Avoid installing/updating plugins or parsers after a failed preflight.
+
+Remove the misleading plain-Vim plugin-install fallback from this path. Do not run Homebrew/npm upgrades automatically.
+
+## Consequences
+
+- Unsupported machines fail clearly instead of receiving a partially broken plugin set.
+- Users must provision Neovim externally before running `install.sh`.
+- Plain Vim installation through this bootstrap is no longer implied.
+- Tests must cover missing Neovim, Neovim below 0.12, supported Neovim, and the guarantee that plugin/parser commands do not run after preflight failure.

--- a/docs/decisions/0017-pin-the-typescript-neovim-stack.md
+++ b/docs/decisions/0017-pin-the-typescript-neovim-stack.md
@@ -1,0 +1,31 @@
+# ADR 0017: Pin the TypeScript Neovim stack
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+The repository currently allows vim-plug dependencies to track their latest upstream commits. The MacBook already demonstrates the failure mode: an updated `nvim-lspconfig` checkout no longer runs on its older Neovim. Installing the same dotfiles on two machines at different times can therefore produce different editor behavior.
+
+The new TypeScript stack combines several APIs that must remain compatible: Neovim core LSP, `nvim-lspconfig`, current-main `nvim-treesitter`, Conform, `nvim-lint`, and Tree-sitter parser revisions.
+
+## Decision
+
+Pin these four plugins to exact commits selected and verified during implementation:
+
+- `neovim/nvim-lspconfig`
+- `nvim-treesitter/nvim-treesitter`
+- `stevearc/conform.nvim`
+- `mfussenegger/nvim-lint`
+
+Keep the Tree-sitter `main` branch declaration together with its tested commit. Parser installation/update must use the parser revisions described by that pinned plugin checkout.
+
+Update pins only as an explicit maintenance change that runs the complete headless/smoke and two-Mac validation suite. Copilot and unrelated existing plugins retain their current update policy but remain covered by coexistence checks.
+
+## Consequences
+
+- Both Macs install the same TypeScript-support plugin code.
+- Upstream fixes and features do not arrive until pins are deliberately advanced.
+- The plan cannot name final commit hashes until implementation verifies the selected checkouts; those hashes must be recorded in the final diff/docs.
+- Plugin inventory/docs and smoke output should report the tested commits to make drift diagnosable.

--- a/docs/decisions/0018-use-nvm-for-node-based-editor-tools.md
+++ b/docs/decisions/0018-use-nvm-for-node-based-editor-tools.md
@@ -1,0 +1,29 @@
+# ADR 0018: Use NVM for Node-based editor tools
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+Both Macs load NVM from the tracked zsh setup. The MacBook's interactive NVM Node works, while its non-interactive Homebrew Node is broken. Mixing Homebrew and NVM ownership for Node-based editor tools would create different PATH and upgrade behavior on the two machines.
+
+The Node-based tools in scope are TypeScript, `typescript-language-server`, Prettier, and ESLint. Projects should still control their own TypeScript/Prettier/ESLint versions when installed locally.
+
+## Decision
+
+Use:
+
+- Homebrew formulas `neovim` and `tree-sitter-cli` on both Macs.
+- Node 24 LTS as the active NVM default on both Macs, with global npm installation of `typescript@5.9.3`, `typescript-language-server`, `prettier`, and `eslint`. TypeScript 5.9.3 is the tested global fallback because npm's current TypeScript 7 package lacks `lib/tsserver.js` and `typescript-language-server` 5.3.0 rejects it.
+- Project-local TypeScript, Prettier, and ESLint before global fallbacks.
+
+All headless/remote verification must load the intended NVM default and report resolved executable paths/versions. Do not hard-code an NVM version directory.
+
+## Consequences
+
+- The provisioning policy is consistent across Apple Silicon and Intel Macs.
+- Changing the NVM default or installing a new Node version may require reinstalling global npm packages; smoke checks detect missing tools.
+- Global Prettier and ESLint remain explicit-only fallbacks under ADRs 0006 and 0007.
+- The global TypeScript pin must be revisited when `typescript-language-server` supports TypeScript 7's packaging; project-local TypeScript remains preferred.
+- Existing Homebrew `tsserver` installations may remain, but the active NVM `PATH` should resolve the NVM-managed tools first and `ts_ls` still launches only `typescript-language-server`.

--- a/docs/decisions/0019-do-not-symlink-repository-docs-to-home.md
+++ b/docs/decisions/0019-do-not-symlink-repository-docs-to-home.md
@@ -1,0 +1,28 @@
+# ADR 0019: Do not symlink repository docs to home
+
+- **Status:** Accepted
+- **Date:** 2026-07-15
+- **Plan:** [`nvim-typescript-support-IMPLEMENTATION_PLAN.md`](../nvim-typescript-support-IMPLEMENTATION_PLAN.md)
+
+## Context
+
+The installer symlinks top-level repository entries into `$HOME` as dotfiles, with explicit skips for files that are installer metadata rather than user configuration. The TypeScript support work added a top-level `docs/` directory for planning artifacts and decision records.
+
+Creating `~/.docs` from this repository planning directory would expose implementation notes as a user dotfile path and make future planning artifacts part of install behavior even though they are not runtime configuration.
+
+## Decision
+
+`install.sh` must skip the top-level `docs/` directory and must not create `~/.docs`.
+
+All other installer behavior remains unchanged:
+
+- The Neovim 0.12+ preflight still runs before any HOME mutation.
+- Existing skips for `install.sh` and `README.md` remain.
+- Other ordinary top-level entries still symlink to `$HOME` as dotfiles.
+- Vim-plug installation, plugin installation, and bounded Tree-sitter parser installation still run for a supported Neovim.
+
+## Consequences
+
+- Planning documents and ADRs stay repository-local.
+- Users do not get a `~/.docs` symlink from this dotfiles installer.
+- Adding future repository-only top-level directories requires an explicit installer decision rather than relying on the broad symlink loop.

--- a/docs/nvim-typescript-support-GLOSSARY.md
+++ b/docs/nvim-typescript-support-GLOSSARY.md
@@ -1,0 +1,29 @@
+# Neovim TypeScript Support Glossary
+
+This glossary records the terms used by the TypeScript-support plan and its decision records.
+
+- **LSP (Language Server Protocol):** The protocol Neovim uses to communicate with a language server for diagnostics, completion, navigation, rename, and code actions.
+- **`tsserver`:** TypeScript's native editor service. It does not speak LSP directly.
+- **`typescript-language-server`:** The executable adapter that wraps `tsserver` and exposes LSP. The standard invocation is `typescript-language-server --stdio`.
+- **`ts_ls`:** The `nvim-lspconfig` configuration name for `typescript-language-server`. It is not an alias for launching raw `tsserver`.
+- **Tree-sitter:** Neovim's parser-based syntax/highlighting system. It is the sole selected TS/TSX highlighter after migration, but it does not provide type checking or other LSP features.
+- **TSX:** TypeScript syntax with JSX, normally detected by Neovim as the `typescriptreact` filetype.
+- **JS/JSX filetypes:** Neovim detects JavaScript as `javascript` and JSX as `javascriptreact`; this effort intentionally applies the same server/parser/format/lint stack to them for mixed projects.
+- **Native LSP completion:** Neovim's built-in `vim.lsp.completion` support, used by this plan instead of a completion framework such as `nvim-cmp`.
+- **Copilot coexistence:** Native LSP completion uses `Ctrl-N`/`Ctrl-P`/`Ctrl-Y`, while `github/copilot.vim` retains insert-mode `Tab` for accepting inline suggestions; each path is tested independently.
+- **Inlay hint:** A non-editing inline annotation supplied by the language server, such as an inferred parameter name or return type. Hints are configured but off by default and toggled per buffer.
+- **Source action:** A whole-file semantic operation such as organize imports, add missing imports, remove unused code, or TypeScript fix-all. This plan exposes source actions only through explicit invocation, never on save.
+- **Balanced diagnostics:** Signs and underlines show warnings/errors, virtual text is limited to errors, and full messages are available through a bordered diagnostic float and navigation mappings.
+- **Native-first mappings:** The plan follows Neovim's `grn`/`gra`/`grr`/`gri` LSP family and adds only focused buffer/tool mappings, avoiding a conflicting bare `gr` or duplicate leader vocabulary.
+- **Project-local tool:** A binary under a project's `node_modules/.bin`, allowing the project to control its TypeScript, Prettier, or ESLint version.
+- **Global fallback:** A tool found on the shell/Neovim `PATH` when no project-local executable exists. Global Prettier is permitted for explicit formatting but never for format-on-save.
+- **Local-only format-on-save:** Automatic formatting that runs whenever `node_modules/.bin/prettier` is found upward from the current buffer; the binary alone is the opt-in signal, its owning project root becomes formatter `cwd`, and no global or LSP formatter fallback is allowed.
+- **Local-only automatic linting:** Post-save linting that runs only when both `node_modules/.bin/eslint` and a discoverable flat/legacy ESLint config are found upward from the current buffer; unconfigured projects skip quietly and global ESLint is explicit-only.
+- **External provisioning:** Installing the `neovim`/`tree-sitter-cli` Homebrew formulas and Node-based editor tools through npm under the active NVM default, rather than through Mason. The tested global TypeScript fallback is 5.9.3 because TypeScript 7 lacks the server module required by `typescript-language-server` 5.3.0.
+- **Supported Macs:** `andrews-mac-mini-1` (current Mac mini) and `qianas-macbook-pro-1` (remote MacBook Pro), connected through Tailscale and expected to run the same tracked dotfiles.
+- **Supported ecosystem:** Standard Node/browser JavaScript and TypeScript projects, including JSX and React-style TSX. Deno and framework-specific Vue/Svelte/Astro/Angular language-server integration are separate future efforts.
+- **Two-layer validation:** Automated disposable-fixture/headless checks plus interactive QA in a real project with local TypeScript, Prettier, and ESLint, performed independently on both supported Macs.
+- **MacBook verification shell:** The interactive zsh/NVM environment used for remote checks because it provides working Node; the broken non-interactive Homebrew Node is outside this effort.
+- **Fail-fast installer preflight:** An `install.sh` check that requires Neovim 0.12+ before any plugin/parser mutation and exits with external upgrade guidance instead of continuing or falling back to plain Vim.
+- **Pinned TypeScript stack:** Exact tested commits for `nvim-lspconfig`, current-main `nvim-treesitter`, Conform, and `nvim-lint`, shared by both Macs and updated only through deliberate maintenance validation.
+- **Repository-only docs:** The top-level `docs/` planning and ADR directory, which `install.sh` intentionally skips instead of creating `~/.docs`.

--- a/docs/nvim-typescript-support-IMPLEMENTATION_PLAN.md
+++ b/docs/nvim-typescript-support-IMPLEMENTATION_PLAN.md
@@ -1,0 +1,427 @@
+# Neovim TypeScript Support Implementation Plan
+
+**Work item:** `nvim-typescript-support` (standalone request; no tracked issue)
+**Mode:** Gap plan — the repository already provides TypeScript filetype/syntax support, but the semantic editing path is not configured.
+**Status:** Phases 1–5 accepted; Phase 6 final review and clean two-Mac verification passed; authorized shipping and post-merge archival remain incomplete.
+**Suggested branch:** `feat/v1.4.0-neovim-typescript-support`
+**Plan date:** 2026-07-14
+**Decision records:** [`ADR 0001`](decisions/0001-require-neovim-0.12-for-typescript-support.md), [`ADR 0002`](decisions/0002-provision-typescript-tools-outside-neovim.md), [`ADR 0003`](decisions/0003-support-javascript-alongside-typescript.md), [`ADR 0004`](decisions/0004-use-ts-ls-language-server.md), [`ADR 0005`](decisions/0005-use-native-lsp-completion-and-preserve-copilot.md), [`ADR 0006`](decisions/0006-format-on-save-with-project-local-prettier.md), [`ADR 0007`](decisions/0007-lint-on-save-with-project-local-eslint.md), [`ADR 0008`](decisions/0008-configure-inlay-hints-with-an-off-by-default-toggle.md), [`ADR 0009`](decisions/0009-keep-typescript-source-actions-explicit.md), [`ADR 0010`](decisions/0010-use-balanced-diagnostic-presentation.md), [`ADR 0011`](decisions/0011-replace-legacy-typescript-syntax-with-tree-sitter.md), [`ADR 0012`](decisions/0012-use-native-first-keybindings.md), [`ADR 0013`](decisions/0013-limit-scope-to-standard-js-ts-and-react-tsx.md), [`ADR 0014`](decisions/0014-validate-with-fixtures-and-real-projects-on-both-macs.md), [`ADR 0015`](decisions/0015-use-the-macbook-nvm-environment-for-verification.md), [`ADR 0016`](decisions/0016-fail-fast-on-unsupported-neovim.md), [`ADR 0017`](decisions/0017-pin-the-typescript-neovim-stack.md), [`ADR 0018`](decisions/0018-use-nvm-for-node-based-editor-tools.md), [`ADR 0019`](decisions/0019-do-not-symlink-repository-docs-to-home.md)
+**Glossary:** [`nvim-typescript-support-GLOSSARY.md`](nvim-typescript-support-GLOSSARY.md)
+**Wayfinder outcome:** Decision-complete in this planning session; no issue-tracker decision map is required.
+
+## 1. Product goal and scope boundaries
+
+### Product goal
+
+Make `.ts` and `.tsx` buffers provide a dependable, project-aware Neovim experience, with the same tooling intentionally available to `.js` and `.jsx` buffers in mixed projects:
+
+- Tree-sitter highlighting for TypeScript, TSX, JavaScript, and JSX.
+- TypeScript language-server attachment with type diagnostics, definition/reference navigation, hover, rename, code actions, import organization, and source-definition navigation.
+- Real LSP completion without replacing Copilot's existing `Tab` behavior, plus explicit Copilot health/coexistence verification.
+- Prettier formatting and ESLint diagnostics that prefer each project's local tools and configuration.
+- Accurate setup, keybinding, health-check, and troubleshooting documentation.
+
+### In scope
+
+- Keep the current Vimscript split, `vim-plug`, and Neovim-first architecture.
+- Require a supported Neovim/toolchain baseline and document how to install it.
+- Consolidate the LSP declarations around one `neovim/nvim-lspconfig` entry.
+- Use Neovim's current `vim.lsp.config`/`vim.lsp.enable` API and native LSP completion.
+- Add `nvim-treesitter`, `conform.nvim`, and `nvim-lint` for parsing, formatting, and linting.
+- Add focused automated smoke coverage plus manual QA in a representative TypeScript project.
+- Update the generated plugin inventory through its generator, never by hand.
+
+### Scope boundaries
+
+- Do not replace `vim-plug`, migrate the whole configuration to Lua, or restructure unrelated editor settings.
+- Do not add `nvim-cmp`: native Neovim completion is sufficient for this scope and avoids a new completion stack/Copilot `Tab` conflict.
+- Do not add Mason or another tool installer. Remove the legacy installers and document external prerequisites instead.
+- Do not install or modify dependencies in users' TypeScript projects. Prefer project-local TypeScript, Prettier, and ESLint when they already exist; use documented global fallbacks only when needed.
+- Enable format-on-save only when the current buffer can resolve an executable project-local `node_modules/.bin/prettier`. Never use global Prettier or `ts_ls` as an automatic-save fallback.
+- Run ESLint automatically after save only when the buffer resolves project-local `node_modules/.bin/eslint` and a flat/legacy ESLint config; global ESLint is explicit-only and unconfigured projects remain quiet.
+- Support standard Node/browser JS/TS, JSX, and React-style TSX only. Defer Deno, Vue, Svelte, Astro, Angular, framework-specific TypeScript plugins, snippets, Telescope integration, and plain Vim compatibility.
+- Preserve all unrelated behavior and the pre-existing uncommitted `zshrc` change; implementation must not touch `zshrc`.
+- Treat the Mac mini and MacBook Pro as supported targets, but do not SSH to or mutate the other machine without explicit authorization.
+- Keep the top-level `docs/` planning directory repository-local; `install.sh` must not create `~/.docs`, while all other top-level symlink behavior and skip rules remain unchanged.
+
+## 2. Architectural decisions
+
+1. **Target Neovim 0.12 or newer (confirmed).** The machine currently has Neovim 0.11.1. The installed `nvim-lspconfig` checkout requires Neovim 0.11.3+, while the current `nvim-treesitter` main branch requires Neovim 0.12+, `tree-sitter` CLI 0.26.1+, `curl`, `tar`, and a C compiler. One Neovim 0.12 baseline satisfies both plugin families. See [ADR 0001](decisions/0001-require-neovim-0.12-for-typescript-support.md).
+2. **Use only `ts_ls`, not raw `tsserver` or an alternative server (confirmed).** `ts_ls` launches `typescript-language-server --stdio`, which wraps `tsserver`. The currently available `/opt/homebrew/bin/tsserver` is not itself an LSP server, and `typescript-language-server` is currently absent. Do not also enable `vtsls` or `typescript-tools.nvim`. See [ADR 0004](decisions/0004-use-ts-ls-language-server.md).
+3. **Let the workspace select TypeScript.** Keep the pinned `nvim-lspconfig` `ts_ls` root/monorepo behavior: the nearest package-manager lockfile or `.git` root starts the server, and Neovim's process cwd is the fallback. This lets the adapter use a project's local TypeScript version when available; do not hard-code the Homebrew `tsserver` path.
+4. **Use native LSP completion and preserve Copilot (confirmed).** Enable `vim.lsp.completion` on `LspAttach`, set completion-menu options, and retain `Ctrl-N`/`Ctrl-P` plus `Ctrl-Y` acceptance. Do not map `Tab`, so Copilot continues to own its existing acceptance path. Verify Copilot independently in headless and interactive modes. See [ADR 0005](decisions/0005-use-native-lsp-completion-and-preserve-copilot.md).
+5. **Use native-first, buffer-local LSP mappings (confirmed).** Explicitly map `gd` and `K` in attached buffers, retain Neovim's `grn`, `gra`, `grr`, and `gri`, and use `[d`/`]d`, `<leader>fm`, `<leader>ll`, and `<leader>ih` for diagnostics and explicit tool actions. `K` remains grep outside attached buffers; do not map bare `gr` or add redundant leader aliases. See [ADR 0012](decisions/0012-use-native-first-keybindings.md).
+6. **Use only the current Tree-sitter main API for TS/TSX (confirmed).** Pin the plugin declaration to `branch: main`, which targets Neovim 0.12+, install the `javascript`, `jsdoc`, `typescript`, and `tsx` parsers with `require('nvim-treesitter').install(...):wait(...)`, and start Tree-sitter for `javascript`, `javascriptreact`, `typescript`, and `typescriptreact`. After verification, remove the legacy TypeScript and inactive TSX declarations rather than maintaining fallback highlighting. See [ADR 0011](decisions/0011-replace-legacy-typescript-syntax-with-tree-sitter.md).
+7. **Separate semantic, lint, and format responsibilities.** `ts_ls` provides type semantics; `nvim-lint` runs ESLint; `conform.nvim` formats with Prettier. Conform must search upward from the buffer directory for `node_modules/.bin/prettier`: automatic formatting is allowed whenever that local binary exists, while explicit `<leader>fm` may fall back to global Prettier. ESLint must search upward for both `node_modules/.bin/eslint` and a flat/legacy config (`eslint.config.*`, `.eslintrc*`, or `package.json` `eslintConfig`): automatic post-save linting is allowed only when both exist, while an explicit lint action may report missing config or fall back to global `eslint`. Both tools execute with the nearest relevant config/package root as `cwd`. See [ADR 0006](decisions/0006-format-on-save-with-project-local-prettier.md) and [ADR 0007](decisions/0007-lint-on-save-with-project-local-eslint.md).
+8. **Fail visibly and diagnostically.** Missing external tools must be discoverable through startup/health documentation and the smoke checker rather than silently leaving the cheatsheet's LSP commands unusable.
+9. **Provision tools outside Neovim (confirmed).** Remove the obsolete LSP installers without adding Mason. Use Homebrew formulas `neovim`/`tree-sitter-cli` and npm under the active NVM default for global TypeScript 5.9.3, `typescript-language-server`, Prettier, and ESLint on both Macs, while preferring project-local tools. TypeScript 5.9.3 is the compatible global fallback because the current TypeScript 7 package lacks `lib/tsserver.js`. See [ADR 0002](decisions/0002-provision-typescript-tools-outside-neovim.md) and [ADR 0018](decisions/0018-use-nvm-for-node-based-editor-tools.md).
+10. **Support mixed JavaScript/TypeScript projects (confirmed).** TypeScript/TSX remain the primary acceptance target, but preserve the upstream server filetype list and configure parsing, formatting, and linting for JavaScript/JSX too. See [ADR 0003](decisions/0003-support-javascript-alongside-typescript.md).
+11. **Offer inlay hints on demand (confirmed).** Configure TypeScript and JavaScript hint preferences, leave display off by default, and add a buffer-local toggle using Neovim's built-in inlay-hint API on the selected 0.12+ baseline. See [ADR 0008](decisions/0008-configure-inlay-hints-with-an-off-by-default-toggle.md).
+12. **Keep TypeScript source actions explicit (confirmed).** Expose code actions and `:LspTypescriptSourceAction`, but never organize imports or apply TypeScript fix-all from a save autocmd. See [ADR 0009](decisions/0009-keep-typescript-source-actions-explicit.md).
+13. **Use balanced diagnostics (confirmed).** Show signs/underlines for warnings and errors, inline virtual text only for errors, severity sorting, a bordered details float, and ASCII-safe signs. See [ADR 0010](decisions/0010-use-balanced-diagnostic-presentation.md).
+14. **Limit ecosystem scope (confirmed).** Support standard Node/browser JS/TS, JSX, and React-style TSX; retain upstream Deno exclusion and add no framework-specific servers. See [ADR 0013](decisions/0013-limit-scope-to-standard-js-ts-and-react-tsx.md).
+15. **Validate fixtures and real projects on both Macs (confirmed).** Run automated/headless checks and interactive project-local QA independently in `~/Documents/Github/sprtsmng` on the Mac mini and `~/draft/draftMachine` on the MacBook Pro. See [ADR 0014](decisions/0014-validate-with-fixtures-and-real-projects-on-both-macs.md).
+16. **Use the MacBook's working NVM login-shell environment (confirmed).** Remote/headless checks must resolve and report tools through interactive zsh/NVM; repairing broken `/usr/local/bin/node` and hard-coding an NVM path are out of scope. See [ADR 0015](decisions/0015-use-the-macbook-nvm-environment-for-verification.md).
+17. **Fail installation fast on unsupported Neovim (confirmed).** Before plugin/parser changes, `install.sh` must require Neovim 0.12+, fail with external upgrade guidance otherwise, and remove the misleading plain-Vim fallback. See [ADR 0016](decisions/0016-fail-fast-on-unsupported-neovim.md).
+18. **Pin the TypeScript plugin stack (confirmed).** Pin `nvim-lspconfig`, current-main `nvim-treesitter`, Conform, and `nvim-lint` to exact commits that pass the complete suite; advance them only through explicit maintenance validation. See [ADR 0017](decisions/0017-pin-the-typescript-neovim-stack.md).
+19. **Use NVM for Node-based editor tools on both Macs (confirmed).** Use Node 24 LTS as the NVM default and install global TypeScript 5.9.3, `typescript-language-server`, Prettier, and ESLint under it; never hard-code a Node-version path, and report resolved paths in verification. See [ADR 0018](decisions/0018-use-nvm-for-node-based-editor-tools.md).
+20. **Do not symlink repository docs into `$HOME` (confirmed).** Treat top-level `docs/` as repository planning and decision-record content, not user dotfile configuration. `install.sh` must skip `docs/` without changing the Neovim preflight, plugin/parser commands, or ordinary top-level symlinks. See [ADR 0019](decisions/0019-do-not-symlink-repository-docs-to-home.md).
+
+## 3. Current baseline
+
+Repository evidence:
+
+- `vimrc` sources `vimrc.bundles`, `vimrc.global`, `vimrc.plugins`, `vimrc.macros`, and `vimrc.local`; Neovim sources this Vim configuration through `~/.config/nvim/init.vim`.
+- `vimrc.bundles` enables `leafgarland/typescript-vim`, declares `neovim/nvim-lspconfig` twice, and also enables the obsolete `kabouzeid/nvim-lspinstall`, `neovim/nvim-lsp`, and `williamboman/nvim-lsp-installer` plugins.
+- `vimrc.bundles` leaves `peitalin/vim-jsx-typescript`, `nvim-treesitter`, `vim-prettier`, and ALE inactive.
+- `vimrc.plugins` contains no LSP, Tree-sitter, formatter, or lint setup.
+- `vimrc.local` assigns `typescriptcomplete#Complete` to `typescript,tx,tsx`; `tx` is a typo and this legacy omnifunc is not semantic LSP completion.
+- `vimrc.global` globally maps `K` to grep. `CHEATSHEET.md` instead describes `K` as LSP hover and presents other LSP actions without stating that they require an attached server.
+- `PLUGIN_INVENTORY.md` is generated by `bin/generate-vim-plugin-inventory`; any added plugins need descriptions in that generator before regeneration.
+- The repository has no editor test suite. Validation currently means sourcing the config and manually checking behavior.
+
+Observed machine baseline on 2026-07-14:
+
+- Neovim: 0.11.1; current Homebrew stable reported as 0.12.4.
+- Installed `nvim-lspconfig` checkout: `cb5bc0b` (2026-04-10), whose README requires Neovim 0.11.3+.
+- `tsserver`: present at `/opt/homebrew/bin/tsserver`.
+- `typescript-language-server`: absent.
+- `prettier`: absent from `PATH`.
+- `eslint`: absent from `PATH`.
+- `tree-sitter`: 0.25.4, below the current `nvim-treesitter` requirement of 0.26.1.
+- C compiler: present.
+
+Observed MacBook baseline from an authorized read-only Tailscale SSH inspection on 2026-07-14:
+
+- Host: `Qianas-MacBook-Pro.local` / `qianas-macbook-pro-1`, Intel `x86_64`, Homebrew prefix `/usr/local`.
+- Neovim: 0.9.5; Tree-sitter CLI: 0.20.8.
+- `typescript-language-server`, global `tsserver`, Prettier, and ESLint: absent from the interactive shell `PATH`.
+- Loading the current config headlessly emits an `nvim-lspconfig` error (`vim.uv` unavailable) because the Neovim version is unsupported.
+- Interactive zsh/NVM provides working Node 24.15.0; non-interactive `/usr/local/bin/node` is broken by a missing ICU dylib, so remote verification must deliberately use the intended shell environment.
+- Copilot command/`Tab` mapping load and headless `:Copilot status` reports ready despite the unrelated LSP startup error.
+- `~/draft/draftMachine` contains TS/TSX, `tsconfig.json`, and local TypeScript 5.3.3, Prettier 3.3.3, and ESLint 8.57.1. ESLint has no discoverable config and fails an stdin probe; ADR 0007 resolves this by skipping automatic lint quietly and testing publish/clear in a disposable configured fixture.
+
+## 4. Missing capabilities
+
+| Capability | Baseline | Target outcome |
+| --- | --- | --- |
+| Supported runtime | Neovim 0.11.1 is below current plugin requirements | Neovim 0.12+ and Tree-sitter CLI 0.26.1+ are documented and verified |
+| TypeScript LSP transport | Only raw `tsserver` is present | `typescript-language-server` launches through `ts_ls` |
+| LSP attachment | No config is enabled | `ts_ls` attaches automatically to TS/TSX project buffers |
+| Diagnostics | No TypeScript semantic diagnostics | Type errors appear through `vim.diagnostic`; ESLint adds project lint findings |
+| Navigation/refactor | Cheatsheet advertises actions without an attached server | Definition, references, implementation, hover, rename, code actions, imports, and source definition work and are documented |
+| Completion | Legacy TypeScript omnifunc | Native LSP completion auto-triggers and remains compatible with Copilot |
+| TSX parsing | Legacy TS syntax only; TSX plugin inactive | Tree-sitter parses and highlights TS/TSX and JSX constructs |
+| Formatting | Prettier integration inactive | Explicit project-aware Prettier formatting via Conform |
+| Linting | ALE inactive | Project-aware ESLint runs after save via `nvim-lint` |
+| Regression checks | Manual sourcing only | Repeatable headless smoke checker plus documented manual QA |
+| Documentation | LSP behavior is overstated and prerequisites are missing | README/CHEATSHEET state prerequisites, attachment checks, mappings, and fallback behavior accurately |
+
+## 5. Milestones / phases
+
+## Phase 1 - Establish the supported runtime and external tool contract
+
+### Goal
+
+Remove version ambiguity before enabling plugins that cannot run on the current machine baseline.
+
+### Deliverables
+
+- Update `README.md` requirements and TypeScript setup notes to require:
+  - Neovim 0.12+.
+  - `tree-sitter` CLI 0.26.1+, `curl`, `tar`, and a C compiler.
+  - `typescript-language-server` plus the compatible TypeScript 5.9.3 global fallback installed through npm under the active NVM default; explain that `tsserver` alone is insufficient and TypeScript 7 currently lacks the required server module.
+  - Global Prettier and ESLint installed under the NVM default as explicit fallbacks, with project-local tools preferred for project behavior.
+- Document architecture-neutral `brew install neovim tree-sitter-cli`, `nvm install 24`, and `npm install -g typescript@5.9.3 typescript-language-server prettier eslint` under the Node 24 NVM default on both Macs. `install.sh` must not mutate global package state; resolve Homebrew, NVM, and tool paths dynamically.
+- Upgrade Homebrew-managed Neovim and Tree-sitter CLI, then install the Node-based tools through npm under each machine's active NVM default before validating later phases.
+- Add an `install.sh` preflight that requires Neovim 0.12+ before any plugin/parser command, exits non-zero with architecture-neutral upgrade guidance on failure, and removes the plain-Vim fallback without installing tools automatically.
+- Keep the top-level `docs/` planning directory out of `$HOME` by making `install.sh` skip `docs/`, while preserving all other top-level symlink behavior.
+- Add a clear health-check command set: `nvim --version`, `tree-sitter --version`, `command -v typescript-language-server`, `:checkhealth vim.lsp`, and `:LspInfo`.
+- Document the same prerequisite and verification flow for `andrews-mac-mini-1` and `qianas-macbook-pro-1`; use Tailscale hostnames in any optional remote-verification instructions.
+
+### Dependencies
+
+- Homebrew or another package manager capable of supplying supported versions.
+- A Node/npm toolchain only if the npm installation route is chosen.
+
+### Risks
+
+- NVM global packages are scoped to a Node installation and may disappear when the default changes. Document reinstall/verification after NVM upgrades. All checks must load the active NVM default; on the MacBook this also avoids the broken non-interactive Homebrew Node.
+- Updating Neovim can expose unrelated deprecated configuration. Capture any startup errors, but keep fixes limited to blockers for this plan.
+
+### Acceptance criteria
+
+- `nvim --version` reports 0.12 or newer.
+- `tree-sitter --version` reports 0.26.1 or newer.
+- `typescript-language-server --version` exits successfully and the executable is on Neovim's `PATH`.
+- README explicitly distinguishes `typescript-language-server`/`ts_ls` from raw `tsserver`.
+- `nvim --headless -u ~/.vimrc +qa` exits successfully before plugin changes continue.
+- Installer tests prove missing/old Neovim fails before plugin/parser execution and supported Neovim proceeds.
+- Installer tests prove supported installation does not create `~/.docs`, still symlinks another ordinary top-level entry, and still invokes vim-plug plus the bounded parser install.
+- Before shipping, the minimum-version and executable checks pass independently on both supported Macs, with remote access performed only when explicitly authorized.
+
+## Phase 2 - Consolidate plugins and enable Tree-sitter parsing
+
+### Goal
+
+Replace redundant/stale TypeScript and LSP declarations with a small, supported plugin set and dependable TSX parsing.
+
+### Deliverables
+
+- In `vimrc.bundles`:
+  - Keep exactly one `neovim/nvim-lspconfig` declaration and pin it to the exact commit selected by implementation verification.
+  - Remove `kabouzeid/nvim-lspinstall`, `neovim/nvim-lsp`, and `williamboman/nvim-lsp-installer`.
+  - Enable `nvim-treesitter/nvim-treesitter` on its `main` branch with its `:TSUpdate` post-update hook, no lazy-loading, and an exact tested commit pin.
+  - Add `stevearc/conform.nvim` and `mfussenegger/nvim-lint`, each pinned to an exact tested commit.
+  - Remove `leafgarland/typescript-vim` and the inactive `peitalin/vim-jsx-typescript` declaration after native filetype detection and Tree-sitter smoke checks pass.
+  - Collapse the duplicate `pangloss/vim-javascript` declarations to one entry; do not otherwise change JavaScript behavior in this phase.
+- In `vimrc.plugins`, configure Tree-sitter with the current API and start it only for the four JS/TS filetypes in scope.
+- In `install.sh`, after plugin installation, synchronously install the four parsers with the equivalent of `nvim --headless -u ~/.vimrc.bundles "+lua require('nvim-treesitter').install({'javascript','jsdoc','typescript','tsx'}):wait(300000)" +qa`. Keep repeated installer runs idempotent; plugin upgrades continue to run `:TSUpdate` through the vim-plug hook.
+- Add descriptions for Conform and `nvim-lint` in `bin/generate-vim-plugin-inventory`, then regenerate `PLUGIN_INVENTORY.md`.
+
+### Dependencies
+
+- Phase 1 runtime and Tree-sitter CLI requirements.
+- Network access during initial plugin/parser installation.
+
+### Risks
+
+- `nvim-treesitter` main is an incompatible rewrite and requires Neovim 0.12. Implement against the README shipped by the installed checkout rather than copying legacy `require('nvim-treesitter.configs').setup` examples.
+- Removing legacy syntax plugins too early can leave TS/TSX unhighlighted if parsers were not installed. Perform parser/filetype verification before `PlugClean!`.
+- `install.sh` currently has a plain-Vim fallback even though the repository is Neovim-first. Remove it under the Phase 1 fail-fast preflight; Phase 2 may assume a supported `nvim` exists.
+
+### Acceptance criteria
+
+- `vimrc.bundles` has one LSP config plugin and none of the three obsolete LSP/install plugins; all four selected TypeScript-stack plugins declare the exact commits verified on both Macs.
+- `:checkhealth nvim-treesitter` succeeds, and `require('nvim-treesitter').get_installed()` contains `javascript`, `jsdoc`, `typescript`, and `tsx`.
+- Opening `.ts` reports `filetype=typescript`; opening `.tsx` reports `filetype=typescriptreact`.
+- `vim.treesitter.highlighter.active[bufnr]` is present for both TS and TSX smoke buffers.
+- TSX elements, TypeScript types/generics, and embedded JavaScript expressions highlight without the legacy TypeScript/TSX syntax plugins.
+- Running `bin/generate-vim-plugin-inventory` produces no uncommitted inventory delta.
+
+## Phase 3 - Enable TypeScript LSP, diagnostics, navigation, and completion
+
+### Goal
+
+Make semantic TypeScript editing attach automatically and expose a coherent, truthful interaction model.
+
+### Deliverables
+
+- In the Neovim-only Lua block in `vimrc.plugins`:
+  - Enable `ts_ls` through `vim.lsp.enable('ts_ls')`; do not use deprecated `require('lspconfig').ts_ls.setup(...)`.
+  - Add one named `LspAttach` augroup that enables native completion only when the client advertises completion support.
+  - Use `completeopt=menu,menuone,noselect,popup` (or the Neovim-0.12 equivalent validated against `:help completeopt`).
+  - Add buffer-local mappings with descriptions for `gd` (definition), `K` (hover), `[d`/`]d` (diagnostics), `<leader>fm` (explicit format), `<leader>ll` (explicit lint), and `<leader>ih` (inlay hints).
+  - Retain and document Neovim's built-in `grn`, `gra`, `grr`, and `gri` mappings; do not map bare `gr` or add duplicate leader aliases for rename/code actions.
+  - Configure balanced diagnostics: signs and underlines for warnings/errors, virtual text only for errors, severity ordering, a bordered details float, previous/next navigation, and ASCII-safe signs.
+  - Configure TypeScript and JavaScript inlay-hint preferences, keep hints disabled initially, and add a documented buffer-local toggle using the built-in API on the selected Neovim 0.12+ baseline.
+- Remove only the TypeScript/TSX `typescriptcomplete#Complete` autocmd from `vimrc.local`, including the `tx` typo; preserve the HTML, CSS, and JavaScript omnifunc entries.
+- Expose and document the `nvim-lspconfig` TypeScript commands `:LspTypescriptSourceAction` and `:LspTypescriptGoToSourceDefinition` when `ts_ls` is attached. All organize-imports, add/remove-imports, and fix-all actions remain explicit; no save autocmd may invoke them.
+- Ensure `K` remains the existing grep command in buffers without an attached LSP and becomes hover in attached TypeScript buffers.
+
+### Dependencies
+
+- Phase 1 `typescript-language-server` executable.
+- Phase 2's single compatible `nvim-lspconfig` declaration.
+- A TypeScript project with a package-manager lockfile or Git root and preferably `tsconfig.json` for realistic validation.
+
+### Risks
+
+- Native completion and Copilot may both display suggestions. Avoid any `Tab` mapping changes; validate `Ctrl-N`/`Ctrl-P`/`Ctrl-Y` for LSP completion and `Tab` for Copilot independently.
+- The current standard `ts_ls` root logic intentionally avoids Deno roots. Deno behavior remains out of scope and must not be overridden.
+- The config sources some split files more than once today. Use named augroups and clear them before defining autocmds so re-sourcing does not duplicate callbacks; do not restructure the source chain in this plan.
+
+### Acceptance criteria
+
+- `:LspInfo` shows one `ts_ls` client attached to representative `.ts`, `.tsx`, `.js`, and `.jsx` buffers.
+- The attached client command is `typescript-language-server --stdio`; no process attempts to launch raw `tsserver` as an LSP.
+- An intentional type error shows an ASCII-safe sign, underline, and inline error text; an intentional warning shows a sign/underline but no inline virtual text. Both can be navigated and inspected in the bordered float.
+- `gd`, `grr`, `gri`, `K`, `grn`, and `gra` perform the documented semantic actions where supported.
+- Rename updates references across files; explicit source actions can organize imports or add/remove imports in a disposable fixture, while an ordinary save performs none of those semantic edits.
+- LSP completion offers project symbols and members, accepts with `Ctrl-Y`, and does not replace Copilot's `Tab` mapping.
+- In a TypeScript buffer, `:Copilot status` reports ready, `Tab` still resolves through `copilot#Accept()`, and an interactive inline suggestion can be rendered and accepted.
+- Inlay hints start disabled, appear only in the current buffer after the toggle, and disappear after toggling again in representative TypeScript and TSX buffers.
+- Non-LSP buffers retain the global `K` grep behavior.
+
+## Phase 4 - Add project-aware Prettier formatting and ESLint linting
+
+### Goal
+
+Provide deterministic formatting and lint feedback without forcing tools or policies into projects that do not use them.
+
+### Deliverables
+
+- Configure `conform.nvim` in `vimrc.plugins` for `typescript`, `typescriptreact`, `javascript`, and `javascriptreact`:
+  - Start from Conform's built-in `prettier` formatter, whose `util.from_node_modules` command searches upward from the current buffer directory for `node_modules/.bin/prettier` before falling back to `prettier` on `PATH`.
+  - Override the formatter `cwd`: when a local binary is found, derive the owning project root by stripping `/node_modules/.bin/prettier` from that nearest executable path; when explicit formatting uses only global Prettier, use the buffer's directory. Do not rely on Conform's config-only built-in Prettier `cwd` or Neovim's process `cwd`.
+  - Add a documented `<leader>fm` buffer-safe format mapping and `:ConformInfo` troubleshooting path; this explicit path may fall back to global Prettier.
+  - Configure format-on-save as a function that returns formatting options whenever an executable `node_modules/.bin/prettier` is found upward from the buffer directory. The binary alone is sufficient—no config/direct-dependency marker is required—and save must not fall back to global Prettier or LSP formatting.
+- Configure `nvim-lint` for the same filetypes using ESLint:
+  - Search upward from the buffer's directory for `node_modules/.bin/eslint` and a flat/legacy config (`eslint.config.*`, `.eslintrc*`, or a `package.json` `eslintConfig` key); do not rely on Neovim having been launched from the package root.
+  - Use the nearest discovered config root as lint `cwd` and pass it to `try_lint`.
+  - Run automatically after successful writes only when both the project-local executable and config exist, using a named augroup; otherwise skip quietly. Avoid duplicate autocmds after re-sourcing and do not lint on `InsertLeave`.
+  - Add a documented explicit lint user command/mapping that prefers local ESLint and may fall back to global `eslint`.
+  - Document a per-buffer/project disable path for untrusted repositories.
+  - Keep TypeScript LSP diagnostics and ESLint diagnostics as separate namespaces visible through `vim.diagnostic`.
+- Handle missing formatter/linter executables without startup errors. The explicit format action should report an actionable message; lint should not emit repeated command-not-found noise.
+- Do not configure `ts_ls` as the primary formatter and do not enable both ALE and `nvim-lint`.
+
+### Dependencies
+
+- Conform and `nvim-lint` from Phase 2.
+- A representative project with local Prettier, ESLint, and TypeScript parser/config packages for end-to-end validation.
+
+### Risks
+
+- ESLint 9/10 flat-config projects and legacy `.eslintrc` projects resolve configuration differently. Validate one real project of each style if both are used; otherwise document the untested style as unknown.
+- Automatically running a project-local executable trusts that project. Limit automatic execution to normal development repositories and document how to disable linting locally for untrusted checkouts.
+- Prettier can create large diffs. A discoverable local binary is the confirmed opt-in boundary; verify that the custom resolver selects the nearest executable and its owning project root, especially in nested monorepo packages.
+
+### Acceptance criteria
+
+- In a project with local Prettier, saving and `<leader>fm` format TS/TSX/JS/JSX according to that project's config, and `:ConformInfo` identifies the local executable.
+- In a trusted project with configured local ESLint, saving a file publishes an intentional lint violation and clearing the violation removes the diagnostic.
+- With local ESLint but no config (including `~/draft/draftMachine`), saving skips lint quietly and explicit lint reports the missing config clearly.
+- With only global ESLint available, saving does not lint, while the explicit lint action can use the global fallback.
+- With only global Prettier available, saving does not format, while explicit `<leader>fm` can use the global fallback.
+- In a project without Prettier/ESLint, Neovim starts and edits normally; missing tools produce no startup exception or automatic file change.
+- TypeScript type diagnostics remain present alongside ESLint diagnostics, with no duplicate ALE diagnostics.
+
+## Phase 5 - Add repeatable verification and align user documentation
+
+### Goal
+
+Prevent the configuration from returning to a state where plugins are declared and cheatsheet features are advertised but no server attaches.
+
+### Deliverables
+
+- Add `bin/check-nvim-typescript-support`, a zsh/bash-compatible smoke checker that:
+  - Validates minimum Neovim and Tree-sitter CLI versions plus required executables.
+  - Asserts that the Copilot command/function load, `Tab` still maps through `copilot#Accept()`, and non-mutating headless `:Copilot status` reports ready; it must never invoke setup/signout or print authentication data.
+  - Creates a disposable TS/TSX fixture outside the repository.
+  - Starts Neovim headlessly with the deployed dotfiles, waits with a bounded timeout, and asserts TypeScript filetype detection, an active Tree-sitter highlighter, one attached `ts_ls` client, completion capability, and an intentional type diagnostic.
+  - Cleans up its fixture and returns non-zero with an actionable failed check.
+- Update `CHEATSHEET.md` with the final completion, LSP, diagnostic, TypeScript source-action, format, lint, and health-check commands. State clearly that semantic mappings require an attached client.
+- Expand `README.md` troubleshooting for missing `typescript-language-server`, unsupported Neovim/Tree-sitter versions, missing project roots, unavailable parsers, and missing project format/lint tools.
+- Run all static and interactive checks listed below.
+
+### Dependencies
+
+- Phases 1–4 complete.
+- A real TS/TSX repository for manual project-local formatter/linter checks.
+
+### Risks
+
+- Headless LSP startup is asynchronous. The checker must use a bounded wait and report client/log state on timeout rather than relying on arbitrary sleeps.
+- Cross-machine SSH checks must run in each machine's intended shell environment and report the resolved Node/Neovim paths; otherwise the MacBook's stale non-interactive Node can create a false failure.
+- NERDTree's `VimEnter` autocmd can change the current headless buffer. The checker must locate the fixture buffer explicitly rather than assume buffer 0 is the TS buffer.
+
+### Acceptance criteria
+
+- `bin/check-nvim-typescript-support` passes on the configured machine and fails clearly when `typescript-language-server` is intentionally hidden from `PATH`.
+- `nvim --headless -u ~/.vimrc +qa` exits zero with no Lua/Vimscript errors.
+- `bin/generate-vim-plugin-inventory` is reproducible and `git diff --check` passes.
+- README and CHEATSHEET mapping names match the actual buffer-local/default mappings.
+- Manual QA passes deeply in `.ts` and `.tsx` files for diagnostics, completion, navigation, rename, imports, formatting, linting, and Copilot coexistence; focused `.js` and `.jsx` checks confirm attachment and no regressions.
+- The smoke checker and real-project interactive QA pass independently on both supported Macs; an unverified machine remains a shipping blocker.
+
+## Phase 6 - Ship and archive the in-flight plan
+
+### Goal
+
+Review and land the focused change without including unrelated dotfile edits, then archive planning artifacts.
+
+### Deliverables
+
+- Review the final diff for scope, plugin redundancy, generated-file correctness, and accidental `zshrc` inclusion.
+- Re-run the full verification matrix after a clean plugin install/update and parser bootstrap.
+- Prepare a focused shipping handoff. Open a PR or perform any GitHub/merge action only if the user explicitly requests and authorizes it.
+- If/when the shipping change merges, move this plan and `docs/nvim-typescript-support-progress.txt` to `docs/archive/` together; otherwise leave both files in `docs/` as in-flight artifacts.
+
+### Dependencies
+
+- Phases 1–5 accepted.
+
+### Risks
+
+- `PlugClean!` is destructive to disabled plugin directories. Run it only after the replacement stack passes and review its target list before confirming.
+- The working tree already contains an unrelated `zshrc` modification; staging must be path-scoped.
+
+### Acceptance criteria
+
+- Final diff contains only TypeScript-support implementation, generated inventory/docs changes, and these planning artifacts.
+- Clean install/update produces the documented pinned plugin commits on both Macs, and smoke/manual checks pass.
+- No unrelated `zshrc` change is staged or shipped.
+- If the change has merged, both synchronized artifacts reside in `docs/archive/` and no in-flight copy remains in `docs/`; otherwise the archive step remains unchecked.
+
+## 6. Test strategy
+
+### Automated/static checks
+
+- `nvim --headless -u ~/.vimrc +qa`
+- `nvim --headless -u ~/.vimrc <fixture.ts> '+Copilot status' +qa` (expect `Copilot: Ready` without invoking setup)
+- `bin/check-nvim-typescript-support`
+- `bin/generate-vim-plugin-inventory`
+- `git diff --check`
+- Fake-home installer tests for missing, old, and supported Neovim, including no preflight HOME mutation, no supported `~/.docs` creation, ordinary top-level symlink preservation, and vim-plug/parser command invocation.
+- Confirm regeneration is clean: `git diff --exit-code -- PLUGIN_INVENTORY.md` after the generator has been run and its intended update is staged/committed.
+
+### Disposable fixture checks
+
+Use a temporary project containing a lockfile, `tsconfig.json`, `.ts`, and `.tsx` files with:
+
+- A cross-file symbol for definition/references/rename.
+- A deliberate assignability error for TypeScript diagnostics.
+- A missing/unused import for source actions.
+- JSX syntax for parser/highlighting checks.
+- A completion site for object members and imported symbols.
+
+### Real-project manual QA
+
+On each supported Mac, use at least one recorded representative project with local TypeScript, Prettier, and ESLint:
+
+- Mac mini: `~/Documents/Github/sprtsmng`; use `apps/web` for primary TSX/Next.js QA and `apps/tui` for an additional TypeScript package. This is a pnpm monorepo with package-level `tsconfig.json` and ESLint flat configs. Its root Prettier binary is sufficient to opt into format-on-save even without a direct root dependency or style config; QA must report the selected executable/version.
+- MacBook Pro: `~/draft/draftMachine`; initial files are `src/app/_components/sidenav.tsx` and `tailwind.config.ts`. Local TypeScript/Prettier work; local ESLint lacks config, so real-project saves must skip lint quietly and a disposable configured fixture covers diagnostic publish/clear without modifying the project.
+
+1. Verify `:set filetype?`, `:LspInfo`, and `:checkhealth vim.lsp`.
+2. Exercise `gd`, `grr`, `gri`, `K`, `grn`, `gra`, explicit source actions, source definition, diagnostic navigation, and the off/on/off buffer-local inlay-hint toggle; confirm ordinary save does not organize imports or apply fix-all.
+3. Confirm native completion with `Ctrl-N`/`Ctrl-P`/`Ctrl-Y`; separately confirm `:Copilot status`, inline suggestion rendering, and Copilot acceptance with `Tab`.
+4. Confirm a project-local Prettier formats on save and through `<leader>fm`; then hide the local binary and confirm global-only Prettier is explicit-only and ordinary save makes no formatting change.
+5. In a disposable trusted fixture with configured local ESLint, save a violation, verify publish/clear, then test global-only explicit behavior. In `draftMachine`, confirm local-but-unconfigured ESLint is skipped quietly and explicit lint explains the missing config.
+6. Re-source `~/.vimrc` and repeat a save/attach check to prove autocmds and clients are not duplicated.
+
+## 7. Acceptance-criteria mapping
+
+| User-visible criterion | Phase(s) | Verification |
+| --- | --- | --- |
+| Supported plugins can load on the installed runtime | 1, 2 | Version commands; headless config load |
+| TS and TSX have modern parsing/highlighting | 2 | Filetype and active highlighter assertions; visual TSX QA |
+| A TypeScript server attaches automatically | 1, 3 | `:LspInfo`; smoke checker client assertion |
+| Type errors and semantic diagnostics appear | 3 | Intentional type error in fixture |
+| Definition, references, implementation, hover, rename, imports, and code actions work | 3 | Fixture navigation/refactor QA |
+| Completion is semantic and does not break Copilot | 3 | LSP completion + Copilot key-path QA |
+| Prettier formatting is available and project-aware | 4 | `<leader>fm`; `:ConformInfo`; project config result |
+| ESLint diagnostics run from project tooling | 4 | Save/fix lint violation; diagnostic namespace check |
+| Docs no longer oversell unattached LSP behavior | 3, 5 | Mapping/config review against README/CHEATSHEET |
+| Setup remains verifiable over time | 2, 5 | Inventory regeneration and smoke checker |
+| Repository planning docs stay repository-local | 1 | Fake-home installer test confirms no `~/.docs` and another ordinary top-level symlink still appears |
+| Unrelated dotfile behavior/change is preserved | All, 6 | Focused diff review; non-LSP `K`; `zshrc` exclusion |
+
+## 8. Out of scope / deferred
+
+- Unconditional format-on-save and any automatic fallback to global Prettier or `ts_ls`.
+- Completion frameworks (`nvim-cmp`), snippets, and completion UI customization beyond native Neovim behavior.
+- Mason or other automatic installation of language servers/formatters/linters.
+- Alternative TypeScript servers such as `vtsls`, `typescript-tools.nvim`, or experimental native `tsgo`/`tsgolint` paths; reconsider only for a demonstrated workflow that `ts_ls` cannot support.
+- Deno routing and framework servers/plugins for Vue, Svelte, Astro, Angular, or GraphQL.
+- Test runners, debugging adapters, coverage UI, or project task execution.
+- Broad cleanup of duplicated config sourcing, old inactive plugins, NERDTree startup, global mappings, or the legacy `mac` bootstrap.
+- Plain Vim support.
+- Repairing the MacBook's broken non-interactive `/usr/local/bin/node`/ICU linkage or hard-coding a machine-specific NVM Node path.
+
+## 9. Immediate next steps
+
+1. Execute Phase 6 final review and clean pinned-stack verification on both Macs while excluding the unrelated `zshrc` change.
+2. Preserve the accepted installer decision that top-level `docs/` is repository-only and must not be symlinked to `~/.docs`.
+3. Prepare the focused shipping handoff and obtain explicit authorization before branch, commit, push, PR, merge, or archive operations.
+4. If the implementation merges, move the synchronized plan and progress artifacts to `docs/archive/` as a follow-up shipping step.

--- a/docs/nvim-typescript-support-progress.txt
+++ b/docs/nvim-typescript-support-progress.txt
@@ -1,0 +1,54 @@
+nvim-typescript-support - Neovim TypeScript Support - Progress
+Generated: 2026-07-14 18:52:38 EDT
+Plan approved: 2026-07-14
+Implementation status: Phases 1–5 accepted; Phase 6 final review and clean two-Mac verification passed; authorized shipping and post-merge archival remain pending
+Plan: docs/nvim-typescript-support-IMPLEMENTATION_PLAN.md
+On completion, move this file and the plan to docs/archive/.
+
+[x] 1.0 - Phase 1 - Establish the supported runtime and external tool contract
+    [x] 1.1 - Update README requirements for Neovim 0.12+, tree-sitter CLI 0.26.1+, build tools, typescript-language-server, Prettier, and ESLint
+    [x] 1.2 - Document Homebrew Neovim/tree-sitter-cli plus Node 24 NVM-global TypeScript 5.9.3/server/Prettier/ESLint checks
+    [x] 1.3 - Add/test install.sh fail-fast Neovim 0.12 preflight and remove the plain-Vim fallback without automatic upgrades
+    [x] 1.4 - Upgrade/verify Neovim, tree-sitter CLI, and typescript-language-server prerequisites on the Mac mini
+    [x] 1.5 - Verify the pre-change config still exits cleanly with nvim --headless -u ~/.vimrc +qa
+    [x] 1.6 - With explicit authorization, verify minimum versions and executables independently on the MacBook Pro
+    [x] 1.7 - Record ADR 0019 and verify install.sh skips top-level docs without changing fail-fast, ordinary symlink, vim-plug, or parser behavior
+
+[x] 2.0 - Phase 2 - Consolidate plugins and enable Tree-sitter parsing
+    [x] 2.1 - Reduce vimrc.bundles to one nvim-lspconfig declaration and remove the three obsolete LSP/install plugins
+    [x] 2.2 - Add exact tested commit pins for nvim-lspconfig, Tree-sitter main, Conform, and nvim-lint; collapse duplicate vim-javascript
+    [x] 2.3 - Configure the Neovim-0.12 Tree-sitter API for JavaScript, JSX, TypeScript, and TSX filetypes
+    [x] 2.4 - Make install.sh run the bounded synchronous parser install for javascript, jsdoc, typescript, and tsx idempotently
+    [x] 2.5 - Verify native TS/TSX filetypes and Tree-sitter highlighters, then remove legacy TypeScript/TSX syntax declarations
+    [x] 2.6 - Add generator descriptions and regenerate PLUGIN_INVENTORY.md
+
+[x] 3.0 - Phase 3 - Enable TypeScript LSP, diagnostics, navigation, and completion
+    [x] 3.1 - Enable ts_ls with vim.lsp.enable and a named, re-source-safe LspAttach augroup
+    [x] 3.2 - Enable native LSP completion with Ctrl-N/Ctrl-P/Ctrl-Y without changing Copilot's Tab mapping
+    [x] 3.3 - Configure balanced diagnostics and the native-first gd/K/gr*/[d/]d/<leader>fm/<leader>ll/<leader>ih mapping model
+    [x] 3.4 - Configure TS/JS inlay-hint preferences and remove the stale TypeScript/tx/TSX omnifunc while preserving unrelated omnifuncs
+    [x] 3.5 - Verify four-filetype attachment, balanced error/warning diagnostics, navigation, rename, explicit source actions, completion, and no semantic save actions
+    [x] 3.6 - Verify inlay hints toggle off/on/off, K remains grep outside LSP buffers, headless Copilot is Ready, and interactive Copilot accepts with Tab
+
+[x] 4.0 - Phase 4 - Add project-aware Prettier formatting and ESLint linting
+    [x] 4.1 - Configure Conform to search upward for local Prettier, format on save only when it exists, and add an explicit leader format mapping
+    [x] 4.2 - Implement/verify custom nearest-Prettier owning-root cwd, prohibit global/LSP save fallback, and document :ConformInfo
+    [x] 4.3 - Auto-lint only when nearest local ESLint and flat/legacy config both exist; use config cwd and never auto-fallback globally
+    [x] 4.4 - Add explicit lint reporting/fallback, a trusted-repo disable path, and quiet missing-tool/missing-config save behavior
+    [x] 4.5 - Verify TS/TSX/JS/JSX local format/lint behavior, unconfigured-local quiet skip, global explicit actions, clearing, and TS coexistence
+
+[x] 5.0 - Phase 5 - Add repeatable verification and align user documentation
+    [x] 5.1 - Add bin/check-nvim-typescript-support with four-filetype, version, executable, Tree-sitter, ts_ls, completion, diagnostics, and Copilot assertions
+    [x] 5.2 - Make the smoke checker bounded, NERDTree-safe, self-cleaning, and actionable on failure
+    [x] 5.3 - Update CHEATSHEET.md completion/LSP/diagnostic/TypeScript/format/lint mappings and attachment caveats
+    [x] 5.4 - Complete README setup and troubleshooting guidance for server, root, parser, formatter, and linter failures
+    [x] 5.5 - Run headless/smoke/inventory checks and interactive QA in ~/Documents/Github/sprtsmng apps/web plus apps/tui on the Mac mini
+    [x] 5.6 - Re-source ~/.vimrc and verify no duplicate autocmds, clients, lint runs, or mappings
+    [x] 5.7 - Provision and run headless/smoke, disposable tools, re-source, and read-only draftMachine QA on the MacBook Pro
+    [x] 5.8 - Complete interactive navigation/completion/Copilot/format/lint QA in draftMachine on the MacBook Pro
+
+[ ] 6.0 - Phase 6 - Ship and archive the in-flight plan
+    [x] 6.1 - Review the final focused diff and exclude the unrelated zshrc modification
+    [x] 6.2 - Re-run clean pinned-plugin/parser installation on both Macs plus the full automated and manual verification matrix
+    [ ] 6.3 - Prepare a focused shipping handoff; open a PR or perform GitHub/merge actions only when explicitly authorized
+    [ ] 6.4 - If/when merged, move docs/nvim-typescript-support-IMPLEMENTATION_PLAN.md and docs/nvim-typescript-support-progress.txt to docs/archive/

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,59 @@
 #!/bin/sh
 
+set -eu
+
+NVIM_BIN="${NVIM_BIN:-nvim}"
+REQUIRED_NVIM_VERSION="0.12.0"
+
+version_ge() {
+  awk -v have="$1" -v need="$2" '
+    BEGIN {
+      split(have, h, ".")
+      split(need, n, ".")
+      for (i = 1; i <= 3; i++) {
+        hv = h[i] + 0
+        nv = n[i] + 0
+        if (hv > nv) exit 0
+        if (hv < nv) exit 1
+      }
+      exit 0
+    }
+  '
+}
+
+require_supported_nvim() {
+  if ! command -v "$NVIM_BIN" >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+ERROR: Neovim 0.12+ is required before installing these dotfiles plugins.
+
+Install or upgrade Neovim first, then rerun ./install.sh.
+On macOS with Homebrew:
+  brew install neovim tree-sitter-cli
+
+The Tree-sitter CLI command must be available as `tree-sitter` and report 0.26.1+.
+EOF
+    exit 1
+  fi
+
+  nvim_version="$("$NVIM_BIN" --version | awk 'NR == 1 { sub(/^NVIM v/, "", $2); sub(/-.*/, "", $2); print $2 }')"
+  if [ -z "$nvim_version" ] || ! version_ge "$nvim_version" "$REQUIRED_NVIM_VERSION"; then
+    cat >&2 <<EOF
+ERROR: Neovim $REQUIRED_NVIM_VERSION or newer is required; found ${nvim_version:-unknown}.
+
+Upgrade Neovim first, then rerun ./install.sh.
+On macOS with Homebrew:
+  brew update
+  brew upgrade neovim
+  brew install tree-sitter-cli
+
+The Tree-sitter CLI command must be available as \`tree-sitter\` and report 0.26.1+.
+EOF
+    exit 1
+  fi
+}
+
+require_supported_nvim
+
 for name in *; do
   target="$HOME/.$name"
   if [ -e "$target" ]; then
@@ -7,7 +61,7 @@ for name in *; do
       echo "WARNING: $target exists but is not a symlink."
     fi
   else
-    if [ "$name" != 'install.sh' ] && [ "$name" != 'README.md' ]; then
+    if [ "$name" != 'install.sh' ] && [ "$name" != 'README.md' ] && [ "$name" != 'docs' ]; then
       echo "Creating $target"
       ln -s "$PWD/$name" "$target"
     fi
@@ -27,8 +81,5 @@ if [ ! -f "$PLUG_PATH" ]; then
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 fi
 
-if command -v nvim >/dev/null 2>&1; then
-  nvim --headless -u ~/.vimrc.bundles "+PlugInstall --sync" +qa
-else
-  vim -u ~/.vimrc.bundles "+PlugInstall --sync" +qa
-fi
+"$NVIM_BIN" --headless -u ~/.vimrc.bundles "+PlugInstall --sync" +qa
+"$NVIM_BIN" --headless -u ~/.vimrc.bundles "+lua require('nvim-treesitter').install({'javascript','jsdoc','typescript','tsx'}):wait(300000)" +qa

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -43,7 +43,6 @@ Plug 'pangloss/vim-javascript'
 Plug 'itchyny/lightline.vim'
 Plug 'airblade/vim-gitgutter'
 " == JavaScript syntax highlighting ==
-Plug 'pangloss/vim-javascript', { 'for': ['javascript', 'javascript.jsx'] }
 "Plug 'mxw/vim-jsx', { 'for': ['javascript', 'javascript.jsx'] }
 "Plug 'othree/yajs.vim', { 'for': ['javascript'] }
 "Plug 'othree/es.next.syntax.vim', { 'for': ['javascript'] }
@@ -66,21 +65,17 @@ Plug 'tpope/vim-sleuth'
 "Plug 'sainnhe/vim-color-forest-night'
 Plug 'rebelot/kanagawa.nvim'
 
-Plug 'leafgarland/typescript-vim'
-"Plug 'peitalin/vim-jsx-typescript'
 "Plug 'styled-components/vim-styled-components', { 'branch': 'main' }
 "Plug 'jparise/vim-graphql'
-Plug 'neovim/nvim-lspconfig'
-Plug 'kabouzeid/nvim-lspinstall'
-Plug 'neovim/nvim-lsp'
-Plug 'williamboman/nvim-lsp-installer'
-Plug 'neovim/nvim-lspconfig'
+Plug 'neovim/nvim-lspconfig', { 'commit': 'cb5bc0b2b35a6d513e3298d285db81453e791f4f' }
+Plug 'nvim-treesitter/nvim-treesitter', { 'branch': 'main', 'commit': '4916d6592ede8c07973490d9322f187e07dfefac', 'do': ':TSUpdate' }
+Plug 'stevearc/conform.nvim', { 'commit': '619363c30309d29ffa631e67c8183f2a72caa373' }
+Plug 'mfussenegger/nvim-lint', { 'commit': '606b823a57b027502a9ae00978ebf4f5d5158098' }
 Plug 'github/copilot.vim'
 "Plug 'nvim-lua/plenary.nvim'
 "Plug 'nvim-telescope/telescope.nvim', { 'tag': '0.1.1' }
 "Plug 'BurntSushi/ripgrep'
 "Plug 'sharkdp/fd'
-"Plug 'nvim-treesitter/nvim-treesitter', {'do': ':TSUpdate'}
 Plug 'ryanoasis/vim-devicons'
 Plug 'ejholmes/vim-forcedotcom'
 

--- a/vimrc.local
+++ b/vimrc.local
@@ -69,7 +69,6 @@ augroup ominfuncs
   autocmd FileType html setlocal omnifunc=htmlcomplete#CompleteTags
   autocmd FileType css,scss,sass set omnifunc=csscomplete#CompleteCSS
   autocmd FileType javascript,jsx setlocal omnifunc=javascriptcomplete#CompleteJS
-  autocmd FileType typescript,tx,tsx setlocal omnifunc=typescriptcomplete#Complete
 augroup END
 "}}}
 autocmd bufread *.cls set ft=apex syntax=apex
@@ -84,5 +83,4 @@ set statusline=%F
 set statusline+=\ %y
 highlight StatusLine guibg=#ffffff guifg=#006086 
 "}}}
-
 

--- a/vimrc.plugins
+++ b/vimrc.plugins
@@ -75,3 +75,361 @@ let g:limelight_priority = -1
 
 let g:ale_sign_error = '❌'
 let g:ale_sign_warning = '⚠️'
+
+if has('nvim')
+  lua << EOF
+local js_ts_filetypes = {
+  javascript = true,
+  javascriptreact = true,
+  typescript = true,
+  typescriptreact = true,
+}
+
+local function is_js_ts(ft)
+  return js_ts_filetypes[ft] == true
+end
+
+local function buf_name(bufnr)
+  return vim.api.nvim_buf_get_name(bufnr or 0)
+end
+
+local function dirname(path)
+  if path == nil or path == '' then
+    return vim.fn.getcwd()
+  end
+  return vim.fs.dirname(path) or vim.fn.getcwd()
+end
+
+local function executable_file(path)
+  return path and vim.fn.executable(path) == 1
+end
+
+local function find_upward(start, names, predicate)
+  local dir = start
+  if dir == nil or dir == '' then
+    dir = vim.fn.getcwd()
+  end
+  local found = vim.fs.find(names, {
+    path = dir,
+    upward = true,
+    stop = vim.loop.os_homedir(),
+    limit = 20,
+    type = 'file',
+  })
+  for _, path in ipairs(found) do
+    if predicate == nil or predicate(path) then
+      return path
+    end
+  end
+  return nil
+end
+
+local function nearest_local_prettier(filename)
+  local path = find_upward(dirname(filename), { 'node_modules/.bin/prettier' }, executable_file)
+  if path then
+    return {
+      command = path,
+      root = path:gsub('/node_modules/%.bin/prettier$', ''),
+    }
+  end
+  return nil
+end
+
+local function package_json_has_eslint_config(path)
+  local ok, lines = pcall(vim.fn.readfile, path)
+  if not ok then
+    return false
+  end
+  local ok_json, package = pcall(vim.json.decode, table.concat(lines, '\n'))
+  return ok_json and type(package) == 'table' and package.eslintConfig ~= nil
+end
+
+local function nearest_eslint_config(filename)
+  local config_names = {
+    'eslint.config.js',
+    'eslint.config.mjs',
+    'eslint.config.cjs',
+    'eslint.config.ts',
+    'eslint.config.mts',
+    'eslint.config.cts',
+    '.eslintrc',
+    '.eslintrc.js',
+    '.eslintrc.cjs',
+    '.eslintrc.yaml',
+    '.eslintrc.yml',
+    '.eslintrc.json',
+    'package.json',
+  }
+  return find_upward(dirname(filename), config_names, function(path)
+    if vim.fs.basename(path) == 'package.json' then
+      return package_json_has_eslint_config(path)
+    end
+    return true
+  end)
+end
+
+local function nearest_local_eslint(filename)
+  local command = find_upward(dirname(filename), { 'node_modules/.bin/eslint' }, executable_file)
+  local config = nearest_eslint_config(filename)
+  if command and config then
+    return {
+      command = command,
+      config = config,
+      cwd = vim.fs.dirname(config),
+    }
+  end
+  return {
+    command = command,
+    config = config,
+  }
+end
+
+local treesitter_ok, treesitter = pcall(require, 'nvim-treesitter')
+if treesitter_ok then
+  local parser_by_ft = {
+    javascript = 'javascript',
+    javascriptreact = 'javascript',
+    typescript = 'typescript',
+    typescriptreact = 'tsx',
+  }
+  local tree_group = vim.api.nvim_create_augroup('DotfilesTreesitter', { clear = true })
+  vim.api.nvim_create_autocmd('FileType', {
+    group = tree_group,
+    pattern = vim.tbl_keys(parser_by_ft),
+    callback = function(args)
+      local lang = parser_by_ft[vim.bo[args.buf].filetype]
+      if lang then
+        pcall(vim.treesitter.start, args.buf, lang)
+      end
+    end,
+  })
+end
+
+local conform_ok, conform = pcall(require, 'conform')
+if conform_ok then
+  conform.setup({
+    formatters_by_ft = {
+      javascript = { 'prettier' },
+      javascriptreact = { 'prettier' },
+      typescript = { 'prettier' },
+      typescriptreact = { 'prettier' },
+    },
+    formatters = {
+      prettier = {
+        command = function(_, ctx)
+          local local_prettier = nearest_local_prettier(ctx.filename)
+          return local_prettier and local_prettier.command or 'prettier'
+        end,
+        cwd = function(_, ctx)
+          local local_prettier = nearest_local_prettier(ctx.filename)
+          return local_prettier and local_prettier.root or dirname(ctx.filename)
+        end,
+      },
+    },
+    format_on_save = function(bufnr)
+      local ft = vim.bo[bufnr].filetype
+      if not is_js_ts(ft) then
+        return nil
+      end
+      if nearest_local_prettier(buf_name(bufnr)) then
+        return { timeout_ms = 5000, lsp_format = 'never' }
+      end
+      return nil
+    end,
+  })
+end
+
+local lint_ok, lint = pcall(require, 'lint')
+if lint_ok then
+  lint.linters_by_ft = {
+    javascript = { 'eslint' },
+    javascriptreact = { 'eslint' },
+    typescript = { 'eslint' },
+    typescriptreact = { 'eslint' },
+  }
+
+  if lint.linters.eslint then
+    lint.linters.eslint.cmd = function()
+      return vim.b.dotfiles_eslint_cmd or 'eslint'
+    end
+  end
+
+  local function reset_eslint_diagnostics(bufnr)
+    local ok_ns, namespace = pcall(lint.get_namespace, 'eslint')
+    if ok_ns and namespace then
+      vim.diagnostic.reset(namespace, bufnr)
+    end
+  end
+
+  function _G.DotfilesTryAutoEslint()
+    local bufnr = vim.api.nvim_get_current_buf()
+    if not is_js_ts(vim.bo[bufnr].filetype) then
+      return
+    end
+    if vim.b[bufnr].dotfiles_eslint_disabled or vim.g.dotfiles_eslint_disabled then
+      reset_eslint_diagnostics(bufnr)
+      return
+    end
+    local eslint = nearest_local_eslint(buf_name(bufnr))
+    if eslint.command and eslint.config then
+      vim.b[bufnr].dotfiles_eslint_cmd = eslint.command
+      lint.try_lint('eslint', { cwd = eslint.cwd })
+    else
+      reset_eslint_diagnostics(bufnr)
+    end
+  end
+
+  local lint_group = vim.api.nvim_create_augroup('DotfilesEslint', { clear = true })
+  vim.api.nvim_create_autocmd('BufWritePost', {
+    group = lint_group,
+    pattern = { '*.js', '*.jsx', '*.ts', '*.tsx' },
+    callback = function()
+      _G.DotfilesTryAutoEslint()
+    end,
+  })
+end
+
+local function explicit_format()
+  if not conform_ok then
+    vim.notify('conform.nvim is not installed', vim.log.levels.WARN)
+    return
+  end
+  local filename = buf_name(0)
+  if not nearest_local_prettier(filename) and vim.fn.executable('prettier') ~= 1 then
+    vim.notify('No project-local or global prettier executable found', vim.log.levels.WARN)
+    return
+  end
+  conform.format({ async = false, timeout_ms = 5000, lsp_format = 'never' })
+end
+
+local function explicit_lint()
+  if not lint_ok then
+    vim.notify('nvim-lint is not installed', vim.log.levels.WARN)
+    return
+  end
+  local bufnr = vim.api.nvim_get_current_buf()
+  local eslint = nearest_local_eslint(buf_name(bufnr))
+  if eslint.command and eslint.config then
+    vim.b[bufnr].dotfiles_eslint_cmd = eslint.command
+    lint.try_lint('eslint', { cwd = eslint.cwd })
+  elseif eslint.command and not eslint.config then
+    vim.notify('Local eslint found, but no eslint.config.*, .eslintrc*, or package.json eslintConfig was found', vim.log.levels.WARN)
+  elseif vim.fn.executable('eslint') == 1 then
+    vim.b[bufnr].dotfiles_eslint_cmd = 'eslint'
+    lint.try_lint('eslint', { cwd = dirname(buf_name(bufnr)) })
+  else
+    vim.notify('No project-local or global eslint executable found', vim.log.levels.WARN)
+  end
+end
+
+vim.api.nvim_create_user_command('DotfilesTypeScriptLintDisable', function()
+  vim.b.dotfiles_eslint_disabled = true
+  if lint_ok then
+    local ok_ns, namespace = pcall(lint.get_namespace, 'eslint')
+    if ok_ns and namespace then
+      vim.diagnostic.reset(namespace, 0)
+    end
+  end
+end, { desc = 'Disable project ESLint for the current buffer' })
+
+vim.diagnostic.config({
+  severity_sort = true,
+  signs = {
+    text = {
+      [vim.diagnostic.severity.ERROR] = 'E',
+      [vim.diagnostic.severity.WARN] = 'W',
+      [vim.diagnostic.severity.INFO] = 'I',
+      [vim.diagnostic.severity.HINT] = 'H',
+    },
+  },
+  underline = {
+    severity = { min = vim.diagnostic.severity.WARN },
+  },
+  virtual_text = {
+    severity = { min = vim.diagnostic.severity.ERROR },
+    source = 'if_many',
+    spacing = 2,
+  },
+  float = {
+    border = 'rounded',
+    source = 'if_many',
+  },
+})
+
+pcall(function()
+  vim.opt.completeopt = { 'menu', 'menuone', 'noselect', 'popup' }
+end)
+
+vim.lsp.config('ts_ls', {
+  settings = {
+    typescript = {
+      inlayHints = {
+        includeInlayParameterNameHints = 'all',
+        includeInlayParameterNameHintsWhenArgumentMatchesName = false,
+        includeInlayFunctionParameterTypeHints = true,
+        includeInlayVariableTypeHints = true,
+        includeInlayVariableTypeHintsWhenTypeMatchesName = false,
+        includeInlayPropertyDeclarationTypeHints = true,
+        includeInlayFunctionLikeReturnTypeHints = true,
+        includeInlayEnumMemberValueHints = true,
+      },
+    },
+    javascript = {
+      inlayHints = {
+        includeInlayParameterNameHints = 'all',
+        includeInlayParameterNameHintsWhenArgumentMatchesName = false,
+        includeInlayFunctionParameterTypeHints = true,
+        includeInlayVariableTypeHints = true,
+        includeInlayVariableTypeHintsWhenTypeMatchesName = false,
+        includeInlayPropertyDeclarationTypeHints = true,
+        includeInlayFunctionLikeReturnTypeHints = true,
+        includeInlayEnumMemberValueHints = true,
+      },
+    },
+  },
+})
+vim.lsp.enable('ts_ls')
+
+local function toggle_inlay_hints(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  local enabled = vim.lsp.inlay_hint.is_enabled({ bufnr = bufnr })
+  vim.lsp.inlay_hint.enable(not enabled, { bufnr = bufnr })
+end
+
+local lsp_group = vim.api.nvim_create_augroup('DotfilesLspAttach', { clear = true })
+vim.api.nvim_create_autocmd('LspAttach', {
+  group = lsp_group,
+  callback = function(args)
+    local bufnr = args.buf
+    local client = vim.lsp.get_client_by_id(args.data.client_id)
+    if client and client:supports_method('textDocument/completion') then
+      pcall(vim.lsp.completion.enable, true, client.id, bufnr, { autotrigger = true })
+    end
+
+    vim.keymap.set('n', 'gd', vim.lsp.buf.definition, { buffer = bufnr, desc = 'LSP definition' })
+    vim.keymap.set('n', 'K', vim.lsp.buf.hover, { buffer = bufnr, desc = 'LSP hover' })
+    vim.keymap.set('n', '[d', function()
+      vim.diagnostic.jump({ count = -1, float = true })
+    end, { buffer = bufnr, desc = 'Previous diagnostic' })
+    vim.keymap.set('n', ']d', function()
+      vim.diagnostic.jump({ count = 1, float = true })
+    end, { buffer = bufnr, desc = 'Next diagnostic' })
+    vim.keymap.set('n', '<leader>fm', explicit_format, { buffer = bufnr, desc = 'Format with Prettier' })
+    vim.keymap.set('n', '<leader>ll', explicit_lint, { buffer = bufnr, desc = 'Lint with ESLint' })
+    vim.keymap.set('n', '<leader>ih', function()
+      toggle_inlay_hints(bufnr)
+    end, { buffer = bufnr, desc = 'Toggle inlay hints' })
+  end,
+})
+
+local ts_tools_group = vim.api.nvim_create_augroup('DotfilesTypeScriptTools', { clear = true })
+vim.api.nvim_create_autocmd('FileType', {
+  group = ts_tools_group,
+  pattern = { 'javascript', 'javascriptreact', 'typescript', 'typescriptreact' },
+  callback = function(args)
+    vim.keymap.set('n', '<leader>fm', explicit_format, { buffer = args.buf, desc = 'Format with Prettier' })
+    vim.keymap.set('n', '<leader>ll', explicit_lint, { buffer = args.buf, desc = 'Lint with ESLint' })
+  end,
+})
+EOF
+endif


### PR DESCRIPTION
## Summary

- require Neovim 0.12+ and provision the tested Node/Tree-sitter TypeScript toolchain
- add pinned Tree-sitter, `ts_ls`, native completion, diagnostics, Conform, and `nvim-lint` configuration for TS/TSX/JS/JSX
- preserve Copilot `Tab`, project-local automatic formatting/linting, and explicit-only global fallbacks
- add repeatable smoke checks, installer safeguards, ADRs, and user documentation
- keep repository-only `docs/` out of the home-directory symlink installer

## Verification

- `bash -n install.sh bin/check-nvim-typescript-support bin/generate-vim-plugin-inventory`
- `git diff --check`
- `nvim --headless -u ~/.vimrc +qa`
- `bin/check-nvim-typescript-support`
- clean pinned-plugin update and parser bootstrap on both supported Macs
- disposable formatting, linting, diagnostics, fallback, re-source, and single-client checks
- interactive TS/TSX/JS/JSX and Copilot QA in `sprtsmng` and `draftMachine` on both Macs
- final independent ARC review: no blocking findings

## Scope note

The unrelated local `zshrc` modification is explicitly excluded from this PR.

## Follow-up

After this PR merges, the synchronized implementation plan and progress tracker will be moved together to `docs/archive/`.
