### PR TITLE
chore(vim,zsh): pin Copilot Node identity and add ARC Pi aliases

### DIFF
--- a/vimrc.plugins
+++ b/vimrc.plugins
@@ -1,3 +1,16 @@
+" Keep Copilot's encrypted master-key access on one signed Node identity.
+" Update this only after verifying the replacement NVM Node's code signature.
+let s:copilot_node_root = expand('~/.nvm/versions/node/v24.18.0')
+let s:copilot_node_command = s:copilot_node_root . '/bin/node'
+let g:copilot_node_command = s:copilot_node_command
+" copilot.vim 1.59 launches through npx by default, so pin that interpreter too.
+let g:copilot_npx_command = [
+      \ '/usr/bin/env',
+      \ 'PATH=' . s:copilot_node_root . '/bin:' . $PATH,
+      \ s:copilot_node_command,
+      \ s:copilot_node_root . '/lib/node_modules/npm/bin/npx-cli.js',
+      \ ]
+
 " Toggle NERDTree
 noremap <C-T> :NERDTreeToggle<CR>
 nmap <leader>n :NERDTreeFind<CR>R

--- a/zshrc
+++ b/zshrc
@@ -90,4 +90,8 @@ export PATH="$PATH:$HOME/.local/bin"
 # Kept out of the repo; sourced last so it can override anything above.
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
 
+# ARC Pi launchers
+alias arc-pi='/Users/andrewsolomon/pi-extend/bin/arc-pi'
+alias arc-orchestrator='/Users/andrewsolomon/pi-extend/bin/arc-orchestrator'
+
 # End of .zshrc configuration


### PR DESCRIPTION
## Summary

Two independent chore commits shipped after `v1.4.0`:

1. `chore(vim): pin Copilot to signed NVM Node for stable Keychain identity`
   - Routes `g:copilot_node_command` and `g:copilot_npx_command` through `/Users/andrewsolomon/.nvm/versions/node/v24.18.0/bin/node` so a single signed Node identity (`TeamIdentifier=HX7739G8FX`) consistently accesses the encrypted Copilot master key in macOS Keychain. Prevents the recurring prompt that occurred when different Node executables (Homebrew unsigned vs NVM signed) reached for the same keychain item.
2. `chore(zsh): add arc-pi and arc-orchestrator aliases`
   - Adds shell aliases for the ARC Pi CLI and orchestrator launchers that are already on disk at `/Users/andrewsolomon/pi-extend/bin/`.

## Verification

- `git diff --check` exits 0 on the branch.
- `nvim --headless -u ~/.vimrc +qa` exits 0.
- `bin/check-nvim-typescript-support` reports `Copilot Ready` and `PASS`.
- `codesign -dv` on the pinned Node binary confirms `TeamIdentifier=HX7739G8FX`.
- Master was reset back to `origin/master` (`48457b3`); these two commits live only on `chore/copilot-pin-and-arc-aliases`.

## Notes

- The Copilot pin intentionally hard-codes the NVM Node version path. Update it only after verifying the replacement Node's code signature.
- The `zshrc` aliases are local-machine convenience; they will only take effect after the host runs `./install.sh` (or symlinks the updated `zshrc`).