### PR TITLE
feat: attach Herdr on interactive SSH login

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -242,7 +242,8 @@ Press prefix, release, then the second key — unless noted as a chord (`Ctrl+a`
 | `Ctrl+a` `s` | Session picker |
 | `Ctrl+a` `(` / `)` | Previous / next session |
 
-SSH auto-attaches to `ssh-$HOST` unless `NO_AUTO_TMUX=1` or `HERDR_ENV=1` (already inside Herdr).
+SSH auto-attaches to Herdr (`exec herdr`) unless `NO_AUTO_TMUX=1` or `HERDR_ENV=1`.
+Falls back to tmux `ssh-$HOST` if Herdr is not installed.
 
 ### Windows
 
@@ -629,8 +630,8 @@ Conventional commit types (for `semantic-release`): `feat:`, `fix:`, `chore:`, `
 
 | Variable | Effect |
 |----------|--------|
-| `NO_AUTO_TMUX=1` | Skip SSH auto-attach to tmux |
-| `HERDR_ENV=1` | Set by Herdr in its panes; also skips SSH auto-tmux |
+| `NO_AUTO_TMUX=1` | Skip SSH auto-attach to Herdr (or tmux fallback) |
+| `HERDR_ENV=1` | Set by Herdr in its panes; also skips SSH auto-attach |
 | `DOTFILES_NERD_FONT=0` | ASCII-safe NERDTree arrows (no icon font) |
 | `T3_CODE_NPX_PACKAGE` | Override package for `npxt3` |
 | `PS1=…` | Override zsh prompt (exported) |
@@ -655,9 +656,9 @@ Use a **Nerd Font** (e.g. Hack Nerd Font) for devicons in nvim unless `DOTFILES_
 ## SSH workflow (this setup)
 
 ```sh
-ssh andrewsolomon@andrews-mac-mini        # auto-attaches tmux (green bar)
-ssh andrewsolomon@qianas-macbook-pro      # blue bar
-NO_AUTO_TMUX=1 ssh user@host              # plain shell, no tmux
+ssh andrewsolomon@andrews-mac-mini        # auto-attaches this machine's Herdr session
+ssh andrewsolomon@qianas-macbook-pro      # Herdr if installed, else tmux (blue bar)
+NO_AUTO_TMUX=1 ssh user@host              # plain shell, no Herdr/tmux
 ```
 
 After dotfiles install on a remote Mac: `./install.sh`, then `source ~/.zshrc`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,11 +96,11 @@ bin/generate-vim-plugin-inventory
 and TPM-managed plugins (`tpm`, `tmux-sensible`, `tmux-resurrect`, `tmux-battery`).
 `.tmux/` holds TPM itself.
 
-SSH shells auto-attach to tmux through `zsh/configs/ssh-tmux.zsh` unless `NO_AUTO_TMUX=1`
-or `HERDR_ENV=1` is set (skip inside a Herdr pane so SSH does not exec tmux). The tmux
-status bar is host-color-coded for known Tailscale Macs:
-`andrews-mac-mini` / `Andrews-Mac-mini` is green, `qianas-macbook-pro` is blue,
-and unknown hosts are yellow.
+SSH shells attach to Herdr through `zsh/configs/post/ssh-herdr.zsh` (`exec herdr`)
+unless `NO_AUTO_TMUX=1` or `HERDR_ENV=1` is set. If Herdr is missing, they fall
+back to tmux (`ssh-$HOST`). The tmux status bar is host-color-coded for known
+Tailscale Macs: `andrews-mac-mini` / `Andrews-Mac-mini` is green,
+`qianas-macbook-pro` is blue, and unknown hosts are yellow.
 
 ### Herdr
 

--- a/README.md
+++ b/README.md
@@ -252,10 +252,11 @@ Known Tailscale Macs get host-specific tmux status colors:
 - `qianas-macbook-pro`: blue
 - Unknown hosts: yellow
 
-Interactive SSH shells auto-attach to a tmux session named `ssh-$HOST` via
-[`zsh/configs/ssh-tmux.zsh`](zsh/configs/ssh-tmux.zsh). Auto-attach is skipped when
-`NO_AUTO_TMUX=1` or when the shell is already inside Herdr (`HERDR_ENV=1`). Bypass
-for one session with:
+Interactive SSH shells attach to the host's Herdr session via
+[`zsh/configs/post/ssh-herdr.zsh`](zsh/configs/post/ssh-herdr.zsh) (`exec herdr`).
+If Herdr is not installed, they fall back to a tmux session named `ssh-$HOST`.
+Skipped when `NO_AUTO_TMUX=1` or when the shell is already inside Herdr
+(`HERDR_ENV=1`). Bypass for one session with:
 
 ```sh
 NO_AUTO_TMUX=1 ssh andrewsolomon@andrews-mac-mini

--- a/zsh/configs/post/ssh-herdr.zsh
+++ b/zsh/configs/post/ssh-herdr.zsh
@@ -1,0 +1,21 @@
+# Auto-attach interactive SSH shells to the host's Herdr session.
+# Skip inside an existing Herdr pane (HERDR_ENV=1) so we do not exec a nested
+# client. NO_AUTO_TMUX=1 remains the escape hatch (plain remote shell).
+#
+# `herdr` often lives in ~/.local/bin, which is appended later in zshrc, so
+# look there explicitly. Fall back to tmux when Herdr is not installed.
+if [[ -o interactive && -n "$SSH_CONNECTION" && -z "$TMUX" && -z "$HERDR_ENV" && -z "$NO_AUTO_TMUX" ]]; then
+  _ssh_herdr=""
+  if command -v herdr >/dev/null 2>&1; then
+    _ssh_herdr="$(command -v herdr)"
+  elif [[ -x "$HOME/.local/bin/herdr" ]]; then
+    _ssh_herdr="$HOME/.local/bin/herdr"
+  fi
+
+  if [[ -n "$_ssh_herdr" ]]; then
+    exec "$_ssh_herdr"
+  elif command -v tmux >/dev/null 2>&1; then
+    _ssh_tmux_host="${HOST%%.*}"
+    exec tmux new-session -A -s "ssh-${_ssh_tmux_host:-remote}"
+  fi
+fi

--- a/zsh/configs/ssh-tmux.zsh
+++ b/zsh/configs/ssh-tmux.zsh
@@ -1,9 +1,0 @@
-# Auto-attach to tmux for interactive SSH shells.
-# Skip inside Herdr (HERDR_ENV=1): a Herdr pane is not a tmux client, so an SSH
-# from one would otherwise exec tmux and nest the wrong multiplexer.
-if [[ -n "$SSH_CONNECTION" && -z "$TMUX" && -z "$HERDR_ENV" && -z "$NO_AUTO_TMUX" ]]; then
-  if command -v tmux >/dev/null 2>&1; then
-    _ssh_tmux_host="${HOST%%.*}"
-    exec tmux new-session -A -s "ssh-${_ssh_tmux_host:-remote}"
-  fi
-fi


### PR DESCRIPTION
## Summary
- Interactive SSH attaches the host's Herdr session (`exec herdr`) instead of a dedicated `ssh-$HOST` tmux session.
- Falls back to tmux when Herdr is not installed. `NO_AUTO_TMUX=1` still opens a plain shell.

## Test plan
- [ ] `ssh andrewsolomon@andrews-mac-mini` from the MacBook lands in the existing Herdr session
- [ ] `NO_AUTO_TMUX=1 ssh andrewsolomon@andrews-mac-mini` is a plain zsh
- [ ] A host without Herdr still gets tmux `ssh-$HOST`
