### PR TITLE
feat: add Mac mini SSH alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,14 +21,17 @@ It is a false positive — this repo has no web app. Ignore it.
 
 - It iterates **every top-level file/dir** and symlinks it to `$HOME/.<name>`
   (e.g. `zshrc` → `~/.zshrc`, `vim/` → `~/.vim`). Skipped: `install.sh`, `README.md`,
-  `docs/` (repo planning), and `herdr/` (XDG config, not `~/.herdr`). A new top-level
-  file named `foo` becomes `~/.foo` on next install — name new files with that in mind.
+  `docs/` (repo planning), `herdr/` (XDG config, not `~/.herdr`), and `ssh/`
+  (installed as `~/.ssh/config`, without managing private keys). A new top-level file
+  named `foo` becomes `~/.foo` on next install — name new files with that in mind.
 - It **never overwrites**: if `~/.<name>` already exists and is not a symlink, it only
   warns. Existing symlinks are left untouched. To re-link after renaming, remove the old
   symlink manually.
 - It writes `~/.config/nvim/init.vim` (containing `source ~/.vimrc`) so Neovim reuses the
   Vim config, installs `vim-plug`, then runs `PlugInstall --sync`.
 - It symlinks `herdr/config.toml` to `~/.config/herdr/config.toml` if that path is missing.
+- It symlinks `ssh/config` to `~/.ssh/config` if that path is missing; keys and
+  `known_hosts` remain machine-local.
 
 ## Reload without reinstalling
 
@@ -116,6 +119,11 @@ symlinks it to `~/.config/herdr/config.toml`. Nested-tmux phase keeps Herdr's pr
 - `tat` — attach/create a tmux session named after the current directory.
 - `git-churn` — rank files by commit frequency.
 - `replace` — project-wide find/replace helper.
+
+### SSH
+
+`ssh/config` is installed as `~/.ssh/config`. It tracks safe host aliases such as
+`ssh mini`; never commit private keys, `known_hosts`, or credentials.
 
 ### Tailscale machine ops
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Personal shell, editor, tmux, and Herdr configuration with a bootstrap installer
 - `vimrc*` and `vim/`: Vim + Neovim settings and plugin config.
 - `tmux.conf` and `.tmux/`: tmux behavior and TPM plugin setup.
 - `bin/`: utility scripts (`git-churn`, `replace`, `tat`, etc).
+- `ssh/config`: tracked host aliases; installed as `~/.ssh/config` without managing private keys.
 - `docs/`: repository planning and decision records; it is intentionally not linked into `$HOME`.
 - `herdr/`: Herdr config; `install.sh` links `herdr/config.toml` to `~/.config/herdr/config.toml` instead of `~/.herdr`.
 
@@ -62,6 +63,7 @@ cd ~/dotfiles
 1. Symlinks each top-level repo item to `$HOME` as a dotfile.
 1. Skips `install.sh`, `README.md`, the repository-only `docs/` planning directory, and `herdr/` (installed into XDG config, not `~/.herdr`).
 1. Warns (does not overwrite) if a destination exists and is not a symlink.
+1. Symlinks `ssh/config` to `~/.ssh/config` if that path is missing; private keys remain unmanaged.
 1. Creates `~/.config/nvim/init.vim` (if missing) with `source ~/.vimrc`.
 1. Symlinks `herdr/config.toml` to `~/.config/herdr/config.toml` if that path is missing.
 1. Installs `vim-plug` for Neovim into:
@@ -288,9 +290,12 @@ Current devices:
 Common SSH targets:
 
 ```sh
-ssh andrewsolomon@andrews-mac-mini
+ssh mini
 ssh andrewsolomon@qianas-macbook-pro
 ```
+
+`ssh mini` is defined in [`ssh/config`](ssh/config) and uses the local
+`~/.ssh/id_ed25519` key for `andrewsolomon@andrews-mac-mini`.
 
 To apply these dotfiles on another Mac:
 

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ require_supported_nvim
 
 skip_top_level() {
   case "$1" in
-    install.sh|README.md|docs|herdr) return 0 ;;
+    install.sh|README.md|docs|herdr|ssh) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -75,6 +75,18 @@ for name in *; do
     ln -s "$PWD/$name" "$target"
   fi
 done
+
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+ssh_config="$HOME/.ssh/config"
+if [ -e "$ssh_config" ] || [ -L "$ssh_config" ]; then
+  if [ ! -L "$ssh_config" ]; then
+    echo "WARNING: $ssh_config exists but is not a symlink."
+  fi
+else
+  echo "Creating $ssh_config"
+  ln -s "$PWD/ssh/config" "$ssh_config"
+fi
 
 mkdir -p "$HOME/.config/nvim"
 if [ ! -f "$HOME/.config/nvim/init.vim" ]; then

--- a/ssh/config
+++ b/ssh/config
@@ -1,0 +1,5 @@
+Host mini
+  HostName andrews-mac-mini
+  User andrewsolomon
+  IdentityFile ~/.ssh/id_ed25519
+  IdentitiesOnly yes


### PR DESCRIPTION
## Summary
- add a tracked `ssh mini` host alias
- install the SSH config without managing private keys
- document the Tailscale SSH workflow

## Verification
- `sh -n install.sh`
- `git diff --check`
- `ssh -G mini` resolves the expected host, user, and identity
- `ssh -o BatchMode=yes mini` connects successfully