### PR TITLE
feat: track Omarchy Caps Lock mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,9 @@ It is a false positive — this repo has no web app. Ignore it.
 
 - It iterates **every top-level file/dir** and symlinks it to `$HOME/.<name>`
   (e.g. `zshrc` → `~/.zshrc`, `vim/` → `~/.vim`). Skipped: `install.sh`, `README.md`,
-  `docs/` (repo planning), `herdr/` (XDG config, not `~/.herdr`), and `ssh/`
-  (installed as `~/.ssh/config`, without managing private keys). A new top-level file
+  `docs/` (repo planning), `herdr/` (XDG config, not `~/.herdr`), `omarchy/`
+  (Omarchy-specific XDG config), and `ssh/` (installed as `~/.ssh/config`, without
+  managing private keys). A new top-level file
   named `foo` becomes `~/.foo` on next install — name new files with that in mind.
 - It **never overwrites**: if `~/.<name>` already exists and is not a symlink, it only
   warns. Existing symlinks are left untouched. To re-link after renaming, remove the old
@@ -32,6 +33,8 @@ It is a false positive — this repo has no web app. Ignore it.
 - It symlinks `herdr/config.toml` to `~/.config/herdr/config.toml` if that path is missing.
 - It symlinks `ssh/config` to `~/.ssh/config` if that path is missing; keys and
   `known_hosts` remain machine-local.
+- On Omarchy, it symlinks `omarchy/hypr/input.lua` to `~/.config/hypr/input.lua`
+  if that path is missing.
 
 ## Reload without reinstalling
 
@@ -119,6 +122,12 @@ symlinks it to `~/.config/herdr/config.toml`. Nested-tmux phase keeps Herdr's pr
 - `tat` — attach/create a tmux session named after the current directory.
 - `git-churn` — rank files by commit frequency.
 - `replace` — project-wide find/replace helper.
+
+### Omarchy
+
+`omarchy/hypr/input.lua` is installed as `~/.config/hypr/input.lua` only on
+Omarchy systems. Validate changes with `hyprctl reload` and `hyprctl configerrors`.
+The tracked override maps Caps Lock to Ctrl with `ctrl:nocaps`.
 
 ### SSH
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Personal shell, editor, tmux, and Herdr configuration with a bootstrap installer
 - `ssh/config`: tracked host aliases; installed as `~/.ssh/config` without managing private keys.
 - `docs/`: repository planning and decision records; it is intentionally not linked into `$HOME`.
 - `herdr/`: Herdr config; `install.sh` links `herdr/config.toml` to `~/.config/herdr/config.toml` instead of `~/.herdr`.
+- `omarchy/hypr/input.lua`: Omarchy keyboard overrides; installed as `~/.config/hypr/input.lua` on Omarchy systems.
 
 ## Requirements
 
@@ -64,6 +65,7 @@ cd ~/dotfiles
 1. Skips `install.sh`, `README.md`, the repository-only `docs/` planning directory, and `herdr/` (installed into XDG config, not `~/.herdr`).
 1. Warns (does not overwrite) if a destination exists and is not a symlink.
 1. Symlinks `ssh/config` to `~/.ssh/config` if that path is missing; private keys remain unmanaged.
+1. On Omarchy, symlinks `omarchy/hypr/input.lua` to `~/.config/hypr/input.lua` if that path is missing.
 1. Creates `~/.config/nvim/init.vim` (if missing) with `source ~/.vimrc`.
 1. Symlinks `herdr/config.toml` to `~/.config/herdr/config.toml` if that path is missing.
 1. Installs `vim-plug` for Neovim into:
@@ -323,6 +325,16 @@ Override the npm package if needed:
 
 ```sh
 T3_CODE_NPX_PACKAGE='actual-package@latest' npxt3
+```
+
+## Omarchy keyboard
+
+The tracked Omarchy input override maps Caps Lock to an additional Ctrl key with
+`kb_options = "ctrl:nocaps"`. Hyprland applies changes automatically; validate them with:
+
+```sh
+hyprctl reload
+hyprctl configerrors
 ```
 
 ## Local machine overrides

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ require_supported_nvim
 
 skip_top_level() {
   case "$1" in
-    install.sh|README.md|docs|herdr|ssh) return 0 ;;
+    install.sh|README.md|docs|herdr|omarchy|ssh) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -86,6 +86,19 @@ if [ -e "$ssh_config" ] || [ -L "$ssh_config" ]; then
 else
   echo "Creating $ssh_config"
   ln -s "$PWD/ssh/config" "$ssh_config"
+fi
+
+if [ -f /etc/os-release ] && grep -q '^ID=omarchy$' /etc/os-release; then
+  mkdir -p "$HOME/.config/hypr"
+  hypr_input="$HOME/.config/hypr/input.lua"
+  if [ -e "$hypr_input" ] || [ -L "$hypr_input" ]; then
+    if [ ! -L "$hypr_input" ]; then
+      echo "WARNING: $hypr_input exists but is not a symlink."
+    fi
+  else
+    echo "Creating $hypr_input"
+    ln -s "$PWD/omarchy/hypr/input.lua" "$hypr_input"
+  fi
 fi
 
 mkdir -p "$HOME/.config/nvim"

--- a/omarchy/hypr/input.lua
+++ b/omarchy/hypr/input.lua
@@ -1,0 +1,64 @@
+-- Keep only your personal input overrides here. Uncommented settings below
+-- replace Omarchy's defaults.
+
+-- Keyboard layout and options.
+-- See https://wiki.hypr.land/Configuring/Basics/Variables/#input
+hl.config({
+  input = {
+    -- Treat Caps Lock as an additional Control key.
+    kb_options = "ctrl:nocaps",
+  },
+})
+
+-- hl.config({
+--   input = {
+--     -- Use multiple keyboard layouts and switch between them with Left Alt + Right Alt.
+--     kb_layout = "us,dk,eu",
+--     kb_options = "compose:caps,shift:both_capslock_cancel,grp:alts_toggle",
+--
+--     -- Use a specific keyboard variant if needed (e.g. intl for international keyboards).
+--     kb_variant = "intl",
+--
+--     -- Change speed of keyboard repeat.
+--     repeat_rate = 40,
+--     repeat_delay = 250,
+--
+--     -- Start with numlock on by default.
+--     numlock_by_default = true,
+--
+--     -- Increase sensitivity for mouse/trackpad (default: 0).
+--     sensitivity = 0.35,
+--
+--     -- Turn off mouse acceleration (default: adaptive).
+--     accel_profile = "flat",
+--
+--     touchpad = {
+--       -- Use natural (inverse) scrolling.
+--       natural_scroll = true,
+--
+--       -- Use two-finger clicks for right-click instead of lower-right corner.
+--       clickfinger_behavior = true,
+--
+--       -- Control the speed of your scrolling.
+--       scroll_factor = 0.4,
+--
+--       -- Enable the touchpad while typing.
+--       disable_while_typing = false,
+--
+--       -- Left-click-and-drag with three fingers.
+--       drag_3fg = 1,
+--     },
+--   },
+-- })
+
+-- App-specific touchpad scroll speeds.
+-- o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
+-- o.window("com.mitchellh.ghostty", { scroll_touchpad = 0.2 })
+
+-- Enable touchpad gestures for changing workspaces.
+-- See https://wiki.hypr.land/Configuring/Advanced-and-Cool/Gestures/
+-- hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
+
+-- Enable touchpad gestures for moving focus (helpful on scrolling layout).
+-- hl.gesture({ fingers = 3, direction = "left", action = function() hl.dispatch(hl.dsp.focus({ direction = "l" })) end })
+-- hl.gesture({ fingers = 3, direction = "right", action = function() hl.dispatch(hl.dsp.focus({ direction = "r" })) end })


### PR DESCRIPTION
## Summary
- track the Omarchy Hyprland input override
- map Caps Lock to an additional Ctrl key
- install the override only on Omarchy systems
- document deployment and validation

## Verification
- `sh -n install.sh`
- `git diff --check`
- `hyprctl reload`
- `hyprctl configerrors` returns no errors
- `hyprctl getoption input:kb_options` reports `ctrl:nocaps`