### PR TITLE
fix: copy Omarchy input config into place

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,9 @@ It is a false positive — this repo has no web app. Ignore it.
 - It symlinks `herdr/config.toml` to `~/.config/herdr/config.toml` if that path is missing.
 - It symlinks `ssh/config` to `~/.ssh/config` if that path is missing; keys and
   `known_hosts` remain machine-local.
-- On Omarchy, it symlinks `omarchy/hypr/input.lua` to `~/.config/hypr/input.lua`
-  if that path is missing.
+- On Omarchy, it copies `omarchy/hypr/input.lua` to `~/.config/hypr/input.lua`.
+  Hyprland's Lua loader requires the module beneath its config root, so this file cannot
+  be an out-of-tree symlink. A differing destination is timestamp-backed up first.
 
 ## Reload without reinstalling
 
@@ -125,9 +126,10 @@ symlinks it to `~/.config/herdr/config.toml`. Nested-tmux phase keeps Herdr's pr
 
 ### Omarchy
 
-`omarchy/hypr/input.lua` is installed as `~/.config/hypr/input.lua` only on
-Omarchy systems. Validate changes with `hyprctl reload` and `hyprctl configerrors`.
-The tracked override maps Caps Lock to Ctrl with `ctrl:nocaps`.
+`omarchy/hypr/input.lua` is copied to `~/.config/hypr/input.lua` only on Omarchy
+systems. It cannot be an out-of-tree symlink because Hyprland's Lua module loader
+requires the file beneath its config root. Validate changes with `hyprctl reload` and
+`hyprctl configerrors`. The tracked override maps Caps Lock to Ctrl with `ctrl:nocaps`.
 
 ### SSH
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Personal shell, editor, tmux, and Herdr configuration with a bootstrap installer
 - `ssh/config`: tracked host aliases; installed as `~/.ssh/config` without managing private keys.
 - `docs/`: repository planning and decision records; it is intentionally not linked into `$HOME`.
 - `herdr/`: Herdr config; `install.sh` links `herdr/config.toml` to `~/.config/herdr/config.toml` instead of `~/.herdr`.
-- `omarchy/hypr/input.lua`: Omarchy keyboard overrides; installed as `~/.config/hypr/input.lua` on Omarchy systems.
+- `omarchy/hypr/input.lua`: Omarchy keyboard overrides; copied to `~/.config/hypr/input.lua` on Omarchy systems.
 
 ## Requirements
 
@@ -65,7 +65,7 @@ cd ~/dotfiles
 1. Skips `install.sh`, `README.md`, the repository-only `docs/` planning directory, and `herdr/` (installed into XDG config, not `~/.herdr`).
 1. Warns (does not overwrite) if a destination exists and is not a symlink.
 1. Symlinks `ssh/config` to `~/.ssh/config` if that path is missing; private keys remain unmanaged.
-1. On Omarchy, symlinks `omarchy/hypr/input.lua` to `~/.config/hypr/input.lua` if that path is missing.
+1. On Omarchy, copies `omarchy/hypr/input.lua` to `~/.config/hypr/input.lua`; a differing existing file is timestamp-backed up first.
 1. Creates `~/.config/nvim/init.vim` (if missing) with `source ~/.vimrc`.
 1. Symlinks `herdr/config.toml` to `~/.config/herdr/config.toml` if that path is missing.
 1. Installs `vim-plug` for Neovim into:
@@ -330,7 +330,10 @@ T3_CODE_NPX_PACKAGE='actual-package@latest' npxt3
 ## Omarchy keyboard
 
 The tracked Omarchy input override maps Caps Lock to an additional Ctrl key with
-`kb_options = "ctrl:nocaps"`. Hyprland applies changes automatically; validate them with:
+`kb_options = "ctrl:nocaps"`. It is copied rather than symlinked because Hyprland's
+Lua module loader requires the module beneath `~/.config/hypr`. Apply repository
+updates with `./install.sh`; a differing destination is backed up first. Hyprland
+applies changes automatically; validate them with:
 
 ```sh
 hyprctl reload

--- a/install.sh
+++ b/install.sh
@@ -90,14 +90,17 @@ fi
 
 if [ -f /etc/os-release ] && grep -q '^ID=omarchy$' /etc/os-release; then
   mkdir -p "$HOME/.config/hypr"
+  hypr_input_source="$PWD/omarchy/hypr/input.lua"
   hypr_input="$HOME/.config/hypr/input.lua"
-  if [ -e "$hypr_input" ] || [ -L "$hypr_input" ]; then
-    if [ ! -L "$hypr_input" ]; then
-      echo "WARNING: $hypr_input exists but is not a symlink."
-    fi
-  else
+  if [ ! -e "$hypr_input" ] && [ ! -L "$hypr_input" ]; then
     echo "Creating $hypr_input"
-    ln -s "$PWD/omarchy/hypr/input.lua" "$hypr_input"
+    cp "$hypr_input_source" "$hypr_input"
+  elif [ -L "$hypr_input" ] || ! cmp -s "$hypr_input_source" "$hypr_input"; then
+    hypr_input_backup="$hypr_input.backup.$(date +%Y%m%d-%H%M%S)"
+    echo "Backing up $hypr_input to $hypr_input_backup"
+    cp -L "$hypr_input" "$hypr_input_backup"
+    rm "$hypr_input"
+    cp "$hypr_input_source" "$hypr_input"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- deploy the Omarchy input module as a managed copy
- back up differing existing input configuration before replacement
- document why an out-of-tree symlink is unsupported

## Verification
- `sh -n install.sh`
- `./install.sh`
- deployed input config is a regular file matching the tracked source
- `hyprctl configerrors` returns no errors
- `hyprctl getoption input:kb_options` reports `ctrl:nocaps`