### PR TITLE
feat: track ssh config in dotfiles and switch herdr to ctrl+a

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # Keyboard & Command Cheat Sheet
 
-Personal reference for this dotfiles setup: **zsh (vi mode) → Herdr (`Ctrl+b`, optional) → tmux (`Ctrl+a`) → Neovim (leader `,`)**.
+Personal reference for this dotfiles setup: **zsh (vi mode) → Herdr (`Ctrl+a`) → Neovim (leader `,`)**.
 
 Print-friendly one-pager. Regenerate or extend as your config changes.
 
@@ -10,17 +10,15 @@ Print-friendly one-pager. Regenerate or extend as your config changes.
 
 ```
 Terminal app (Ghostty / iTerm / etc.)
-  └─ herdr        outer multiplexer (prefix Ctrl+b); optional while tmux is nested
+  └─ herdr        multiplexer (prefix Ctrl+a)
        └─ zsh     history, completion, aliases, shell functions
-            └─ tmux   sessions, windows, panes, copy mode
-                 └─ nvim   edit files, grep, LSP, Copilot, NERDTree
+            └─ nvim   edit files, grep, LSP, Copilot, NERDTree
 ```
 
 | Layer | Prefix / mode | Escape hatch |
 |-------|---------------|--------------|
 | zsh | `Esc` → vi command mode | `Ctrl+C` cancel, `Ctrl+D` logout |
-| herdr | `Ctrl+b` then key | `Ctrl+b` `q` detach |
-| tmux | `Ctrl+a` then key | `Ctrl+a` `d` detach |
+| herdr | `Ctrl+a` then key | `Ctrl+a` `q` detach |
 | nvim | `,` leader, `jk` = Esc | `:q!` force quit |
 
 ---
@@ -32,11 +30,11 @@ Terminal app (Ghostty / iTerm / etc.)
 | `Ctrl+R` | Search shell history |
 | `Ctrl+A` / `Ctrl+E` | Line start / end (shell) |
 | `Ctrl+Q` | Stash current line, run something else, pop it back |
-| `Ctrl+a` | tmux prefix |
-| `Ctrl+a` `"` / `%` | Split pane horizontal / vertical |
-| `Ctrl+a` `h/j/k/l` | Move between tmux panes |
-| `Ctrl+a` `d` | Detach from tmux |
-| `Ctrl+a` `[` | tmux copy mode |
+| `Ctrl+a` | herdr prefix |
+| `Ctrl+a` `v` / `-` | Split pane right / down |
+| `Ctrl+a` `h/j/k/l` | Move between herdr panes |
+| `Ctrl+a` `q` | Detach from herdr |
+| `Ctrl+a` `[` | herdr copy mode |
 | `,` | Neovim leader |
 | `jk` | Leave insert mode (Neovim) |
 | `,,` | Toggle previous buffer |
@@ -326,14 +324,13 @@ restore relaunches with `--session` or `--resume`. Debug mapping:
 
 ## Herdr
 
-Outer multiplexer while tmux is still nested. Prefix is `Ctrl+b` so it does not
-fight tmux `Ctrl+a`. Config: `herdr/config.toml` → `~/.config/herdr/config.toml`.
+Multiplexer. Prefix is `Ctrl+a`. Config: `herdr/config.toml` → `~/.config/herdr/config.toml`.
 
 | Keys | Action |
 |------|--------|
 | `herdr` | Attach (or start) the default session |
-| `Ctrl+b` `q` | Detach Herdr (panes keep running) |
-| `Ctrl+b` `?` | Show live keybindings |
+| `Ctrl+a` `q` | Detach Herdr (panes keep running) |
+| `Ctrl+a` `?` | Show live keybindings |
 | `herdr server reload-config` | Reload `config.toml` |
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,14 +24,14 @@ It is a false positive — this repo has no web app. Ignore it.
   `docs/` (repo planning), `herdr/` (XDG config, not `~/.herdr`), and `ssh/`
   (installed as `~/.ssh/config`, without managing private keys). A new top-level file
   named `foo` becomes `~/.foo` on next install — name new files with that in mind.
-- It **never overwrites**: if `~/.<name>` already exists and is not a symlink, it only
-  warns. Existing symlinks are left untouched. To re-link after renaming, remove the old
-  symlink manually.
+- It **never overwrites** top-level `~/.<name>` targets: if the destination already exists
+  and is not a symlink, it only warns. Existing symlinks are left untouched. To re-link
+  after renaming, remove the old symlink manually.
 - It writes `~/.config/nvim/init.vim` (containing `source ~/.vimrc`) so Neovim reuses the
   Vim config, installs `vim-plug`, then runs `PlugInstall --sync`.
 - It symlinks `herdr/config.toml` to `~/.config/herdr/config.toml` if that path is missing.
-- It symlinks `ssh/config` to `~/.ssh/config` if that path is missing; keys and
-  `known_hosts` remain machine-local.
+- It symlinks `ssh/config` to `~/.ssh/config`. A pre-existing real file is backed up to
+  `~/.ssh/config.pre-dotfiles`. Keys and `known_hosts` remain machine-local.
 
 ## Reload without reinstalling
 
@@ -108,8 +108,7 @@ Tailscale Macs: `andrews-mac-mini` / `Andrews-Mac-mini` is green,
 ### Herdr
 
 `herdr/config.toml` is repository-only at the top level (not `~/.herdr`). `install.sh`
-symlinks it to `~/.config/herdr/config.toml`. Nested-tmux phase keeps Herdr's prefix on
-`ctrl+b` so it does not collide with tmux `Ctrl+a`. Completions live in
+symlinks it to `~/.config/herdr/config.toml`. Prefix is `ctrl+a`. Completions live in
 `zsh/completion/_herdr`.
 
 ### bin/ utilities (on PATH)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ cd ~/dotfiles
 1. Symlinks each top-level repo item to `$HOME` as a dotfile.
 1. Skips `install.sh`, `README.md`, the repository-only `docs/` planning directory, and `herdr/` (installed into XDG config, not `~/.herdr`).
 1. Warns (does not overwrite) if a destination exists and is not a symlink.
-1. Symlinks `ssh/config` to `~/.ssh/config` if that path is missing; private keys remain unmanaged.
+1. Symlinks `ssh/config` to `~/.ssh/config`. If a real file is already there, it is moved to `~/.ssh/config.pre-dotfiles` first. Private keys remain unmanaged.
 1. Creates `~/.config/nvim/init.vim` (if missing) with `source ~/.vimrc`.
 1. Symlinks `herdr/config.toml` to `~/.config/herdr/config.toml` if that path is missing.
 1. Installs `vim-plug` for Neovim into:
@@ -270,9 +270,8 @@ Herdr config is tracked as [`herdr/config.toml`](herdr/config.toml) and installe
 `~/.config/herdr/config.toml`. The top-level `herdr/` directory is not symlinked to
 `~/.herdr`.
 
-While tmux is still nested inside Herdr, the prefix stays `ctrl+b` so it does not
-collide with tmux `Ctrl+a`. Detach Herdr with `Ctrl+b q`; detach tmux with
-`Ctrl+a d`. Reload a running server with `herdr server reload-config`.
+Prefix is `ctrl+a`. Detach with `Ctrl+a q`. Reload a running server with
+`herdr server reload-config`.
 
 zsh completion is generated into [`zsh/completion/_herdr`](zsh/completion/_herdr)
 (`herdr completion zsh`). Re-source `~/.zshrc` (or open a new shell) after install.

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -1,10 +1,27 @@
-# Nested-tmux phase: Herdr stays on ctrl+b so it does not fight tmux's Ctrl+a prefix.
-# Do not run tmux2herdr against this file until panes live in Herdr instead of
-# inside `tmux attach`.
+# Herdr is the multiplexer. Prefix is Ctrl+a (same chord as the old tmux config).
 
 [ui]
 agent_panel_sort = "spaces"
 mouse_capture = true
 
 [keys]
-prefix = "ctrl+b"
+prefix = "ctrl+a"
+
+# Keep Control held after the prefix. Without these aliases Herdr sees ctrl+h
+# (etc.), finds no binding, and silently drops the key.
+help = ["prefix+?", "prefix+ctrl+/"]
+detach = ["prefix+q", "prefix+ctrl+q"]
+goto = ["prefix+g", "prefix+ctrl+g"]
+workspace_picker = ["prefix+w", "prefix+ctrl+w"]
+new_tab = ["prefix+c", "prefix+ctrl+c"]
+previous_tab = ["prefix+p", "prefix+ctrl+p"]
+next_tab = ["prefix+n", "prefix+ctrl+n"]
+focus_pane_left = ["prefix+h", "prefix+ctrl+h"]
+focus_pane_down = ["prefix+j", "prefix+ctrl+j"]
+focus_pane_up = ["prefix+k", "prefix+ctrl+k"]
+focus_pane_right = ["prefix+l", "prefix+ctrl+l"]
+split_vertical = ["prefix+v", "prefix+ctrl+v"]
+split_horizontal = ["prefix+minus", "prefix+ctrl+minus"]
+close_pane = ["prefix+x", "prefix+ctrl+x"]
+zoom = ["prefix+z", "prefix+ctrl+z"]
+toggle_sidebar = ["prefix+b", "prefix+ctrl+b"]

--- a/install.sh
+++ b/install.sh
@@ -79,13 +79,21 @@ done
 mkdir -p "$HOME/.ssh"
 chmod 700 "$HOME/.ssh"
 ssh_config="$HOME/.ssh/config"
-if [ -e "$ssh_config" ] || [ -L "$ssh_config" ]; then
-  if [ ! -L "$ssh_config" ]; then
-    echo "WARNING: $ssh_config exists but is not a symlink."
+ssh_source="$PWD/ssh/config"
+if [ -L "$ssh_config" ]; then
+  current="$(readlink "$ssh_config")"
+  if [ "$current" != "$ssh_source" ]; then
+    echo "WARNING: $ssh_config is a symlink to $current, not $ssh_source."
   fi
+elif [ -e "$ssh_config" ]; then
+  backup="${ssh_config}.pre-dotfiles"
+  echo "Backing up $ssh_config to $backup"
+  mv "$ssh_config" "$backup"
+  echo "Creating $ssh_config"
+  ln -s "$ssh_source" "$ssh_config"
 else
   echo "Creating $ssh_config"
-  ln -s "$PWD/ssh/config" "$ssh_config"
+  ln -s "$ssh_source" "$ssh_config"
 fi
 
 mkdir -p "$HOME/.config/nvim"

--- a/ssh/config
+++ b/ssh/config
@@ -1,5 +1,14 @@
+# Installed as ~/.ssh/config. Private keys stay machine-local (~/.ssh/id_*).
+# UseKeychain is macOS-only; IgnoreUnknown keeps Linux OpenSSH happy.
+
 Host mini
   HostName andrews-mac-mini
   User andrewsolomon
   IdentityFile ~/.ssh/id_ed25519
   IdentitiesOnly yes
+
+Host *
+  AddKeysToAgent yes
+  IdentityFile ~/.ssh/id_ed25519
+  IgnoreUnknown UseKeychain
+  UseKeychain yes


### PR DESCRIPTION
## Summary
- Install `ssh/config` as `~/.ssh/config` (backup any real file to `~/.ssh/config.pre-dotfiles`) so `ssh mini` and Keychain settings live in the repo.
- Make Herdr the multiplexer with prefix `Ctrl+a`, including ctrl-held aliases so prefix chords still work at typing speed.

## Test plan
- [x] `ssh -G mini` resolves to `andrewsolomon@andrews-mac-mini`
- [x] `~/.ssh/config` is a symlink to `dotfiles/ssh/config`
- [ ] `./install.sh` on another machine backs up an existing `~/.ssh/config` and links the repo file
- [ ] In Herdr, `Ctrl+a` then `?` opens keybind help (Control may stay held)


Made with [Cursor](https://cursor.com)