### PR TITLE
fix: improve Tailscale SSH workflow

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -653,9 +653,9 @@ Use a **Nerd Font** (e.g. Hack Nerd Font) for devicons in nvim unless `DOTFILES_
 ## SSH workflow (this setup)
 
 ```sh
-ssh andrewsolomon@andrews-mac-mini        # auto-attaches this machine's Herdr session
-ssh andrewsolomon@qianas-macbook-pro      # Herdr if installed, else tmux (blue bar)
-NO_AUTO_TMUX=1 ssh user@host              # plain shell, no Herdr/tmux
+ssh mini                                  # auto-attaches this machine's Herdr session
+ssh macbook                               # Herdr if installed, else tmux (blue bar)
+ssh -t macbook 'NO_AUTO_TMUX=1 exec zsh -l' # plain shell, no Herdr/tmux
 ```
 
 After dotfiles install on a remote Mac: `./install.sh`, then `source ~/.zshrc`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,13 +132,13 @@ requires the file beneath its config root. Validate changes with `hyprctl reload
 
 ### SSH
 
-`ssh/config` is installed as `~/.ssh/config`. It tracks safe host aliases such as
-`ssh mini`; never commit private keys, `known_hosts`, or credentials.
+`ssh/config` is installed as `~/.ssh/config`. It tracks safe host aliases `ssh mini`
+and `ssh macbook`; never commit private keys, `known_hosts`, or credentials.
 
 ### Tailscale machine ops
 
-Use `.agents/skills/tailscale-machine-ops/SKILL.md` as the shared machine inventory for
-Codex and Claude Code. Current known devices:
+Use this shared machine inventory for remote operations. Confirm `hostname` and
+`whoami` before changing another machine. Current known devices:
 
 - `andrews-mac-mini` / `Andrews-Mac-mini` / `100.77.5.31` / macOS / current Mac mini.
 - `qianas-macbook-pro` / `100.122.22.119` / macOS / other MacBook Pro.

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ require project-local tools.
 On the supported Macs, use the same login-shell flow:
 
 ```sh
-NO_AUTO_TMUX=1 ssh andrewsolomon@andrews-mac-mini 'cd ~/dotfiles && zsh -lic "bin/check-nvim-typescript-support"'
-NO_AUTO_TMUX=1 ssh andrewsolomon@qianas-macbook-pro 'cd ~/dotfiles && zsh -lic "bin/check-nvim-typescript-support"'
+ssh mini 'export NO_AUTO_TMUX=1; cd ~/dotfiles && zsh -lic "bin/check-nvim-typescript-support"'
+ssh macbook 'export NO_AUTO_TMUX=1; cd ~/dotfiles && zsh -lic "bin/check-nvim-typescript-support"'
 ```
 
 Do not run the remote command until you intend to verify that machine; these checks
@@ -260,10 +260,10 @@ Interactive SSH shells attach to the host's Herdr session via
 [`zsh/configs/post/ssh-herdr.zsh`](zsh/configs/post/ssh-herdr.zsh) (`exec herdr`).
 If Herdr is not installed, they fall back to a tmux session named `ssh-$HOST`.
 Skipped when `NO_AUTO_TMUX=1` or when the shell is already inside Herdr
-(`HERDR_ENV=1`). Bypass for one session with:
+(`HERDR_ENV=1`). Bypass for one session by setting the variable on the remote shell:
 
 ```sh
-NO_AUTO_TMUX=1 ssh andrewsolomon@andrews-mac-mini
+ssh -t mini 'NO_AUTO_TMUX=1 exec zsh -l'
 ```
 
 ## Herdr
@@ -280,8 +280,8 @@ zsh completion is generated into [`zsh/completion/_herdr`](zsh/completion/_herdr
 
 ## Tailscale machine workflow
 
-Shared machine details for Codex and Claude Code live in
-[`.agents/skills/tailscale-machine-ops/SKILL.md`](.agents/skills/tailscale-machine-ops/SKILL.md).
+Use this inventory when operating across the Tailscale-connected Macs. Confirm
+`hostname` and `whoami` before making changes on a remote machine.
 
 Current devices:
 
@@ -292,11 +292,12 @@ Common SSH targets:
 
 ```sh
 ssh mini
-ssh andrewsolomon@qianas-macbook-pro
+ssh macbook
 ```
 
-`ssh mini` is defined in [`ssh/config`](ssh/config) and uses the local
-`~/.ssh/id_ed25519` key for `andrewsolomon@andrews-mac-mini`.
+Both aliases are defined in [`ssh/config`](ssh/config) and use the local
+`~/.ssh/id_ed25519` key. `mini` connects to `andrews-mac-mini`; `macbook`
+connects to `qianas-macbook-pro`.
 
 To apply these dotfiles on another Mac:
 

--- a/ssh/config
+++ b/ssh/config
@@ -7,6 +7,12 @@ Host mini
   IdentityFile ~/.ssh/id_ed25519
   IdentitiesOnly yes
 
+Host macbook
+  HostName qianas-macbook-pro
+  User andrewsolomon
+  IdentityFile ~/.ssh/id_ed25519
+  IdentitiesOnly yes
+
 Host *
   AddKeysToAgent yes
   IdentityFile ~/.ssh/id_ed25519


### PR DESCRIPTION
## Summary
- add a passwordless `ssh macbook` alias
- set `NO_AUTO_TMUX` on the remote side in bypass examples
- remove references to the intentionally untracked `.agents` skill
- use the tracked aliases consistently in documentation

## Verification
- `sh -n install.sh`
- `git diff --check`
- no stale `NO_AUTO_TMUX=1 ssh` or `.agents` skill references remain
- `ssh mini` connects successfully
- `ssh macbook` connects successfully