### PR TITLE
fix: update mise-managed Pi through launchers

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -206,6 +206,7 @@ Machine-specific aliases: `~/.aliases.local`
 | `tat` | `tmux attach -t $(basename $PWD)` — session per directory |
 | `replace old new files…` | Find/replace across files via `ag` + `sed` |
 | `git-churn` | Rank changed files by commit frequency vs `origin/main` |
+| `pi update` / `arc-pi update` | Update the mise-managed Pi installation |
 | `npxt3` | Run T3 Code via `npx -y ${T3_CODE_NPX_PACKAGE:-t3@latest}` |
 | `generate-vim-plugin-inventory` | Regenerate `PLUGIN_INVENTORY.md` |
 
@@ -215,6 +216,7 @@ Examples:
 tat
 replace foo bar **/*.ts
 git-churn
+pi update
 T3_CODE_NPX_PACKAGE='actual-package@latest' npxt3
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,8 @@ symlinks it to `~/.config/herdr/config.toml`. Prefix is `ctrl+a`. Completions li
 ### bin/ utilities (on PATH)
 
 - `generate-vim-plugin-inventory` — see above.
+- `pi` — forward normal commands to mise-managed Pi; translate Pi self-updates to
+  `mise upgrade pi`, including updates requested through ARC Pi.
 - `npxt3` — run T3 Code through `npx -y ${T3_CODE_NPX_PACKAGE:-t3@latest}`.
 - `tat` — attach/create a tmux session named after the current directory.
 - `git-churn` — rank files by commit frequency.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Personal shell, editor, tmux, and Herdr configuration with a bootstrap installer
 - [Requirements](#requirements)
 - [Install](#install)
 - [How install works](#how-install-works)
+- [Pi updates](#pi-updates)
 - [Neovim and Vim](#neovim-and-vim)
 - [Plugin management](#plugin-management)
 - [Key mappings and usage](#key-mappings-and-usage)
@@ -76,6 +77,20 @@ cd ~/dotfiles
    - `javascript`, `jsdoc`, `typescript`, and `tsx`
 
 `install.sh` does not install or upgrade Homebrew or npm packages.
+
+## Pi updates
+
+Pi is installed and versioned by mise, so its bundled executable cannot update
+itself directly. The tracked [`bin/pi`](bin/pi) launcher translates self-update
+requests to mise while preserving Pi's normal package and model commands:
+
+```sh
+pi update          # update mise-managed Pi
+arc-pi update      # same update through the ARC Pi launcher
+pi update --models # refresh Pi's model catalogs
+```
+
+Both `pi` and `arc-pi` resolve this launcher through `~/.bin` in login zsh shells.
 
 ## Neovim and Vim
 

--- a/bin/pi
+++ b/bin/pi
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Make Pi's update commands work when the Pi executable is managed by mise.
+set -euo pipefail
+
+update_pi() {
+  if [[ "${1:-}" == "--force" ]]; then
+    MISE_MINIMUM_RELEASE_AGE=0 mise install --force pi@latest
+  else
+    MISE_MINIMUM_RELEASE_AGE=0 mise upgrade pi
+  fi
+}
+
+case "${1:-}" in
+  update)
+    case "${2:-}" in
+      ""|pi|self|--self)
+        update_pi "${3:-}"
+        exit
+        ;;
+      --all)
+        update_pi
+        pi_bin="$(mise which pi)"
+        exec "$pi_bin" update --extensions "${@:3}"
+        ;;
+    esac
+    ;;
+esac
+
+pi_bin="$(mise which pi)"
+exec "$pi_bin" "$@"

--- a/zshrc
+++ b/zshrc
@@ -90,8 +90,4 @@ export PATH="$PATH:$HOME/.local/bin"
 # Kept out of the repo; sourced last so it can override anything above.
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
 
-# ARC Pi launchers
-alias arc-pi='/Users/andrewsolomon/pi-extend/bin/arc-pi'
-alias arc-orchestrator='/Users/andrewsolomon/pi-extend/bin/arc-orchestrator'
-
 # End of .zshrc configuration


### PR DESCRIPTION
## Summary
- add a tracked Pi launcher that delegates self-updates to mise
- make both `pi update` and `arc-pi update` update the managed installation
- preserve Pi package and model update commands
- remove stale macOS-only ARC aliases
- document the update workflow

## Verification
- `bash -n bin/pi`
- `git diff --check`
- `pi update` upgraded Pi from 0.84.3 to 0.84.4
- `arc-pi update` reports all tools current
- `pi update --models` refreshes model catalogs
- both `pi --version` and `arc-pi --version` report 0.84.4