### PR TITLE
feat: persist Herdr sessions and manage Omarchy config

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -335,6 +335,12 @@ Multiplexer. Prefix is `Ctrl+a`. Config: `herdr/config.toml` → `~/.config/herd
 | `Ctrl+a` `?` | Show live keybindings |
 | `herdr server reload-config` | Reload `config.toml` |
 
+Herdr automatically snapshots workspace, tab, and pane topology. Native
+agent-session resume requires current official integrations. This config enables
+it with `resume_agents_on_restore = true`. Normal Pi uses `~/.pi/agent`; ARC Pi
+uses `~/.arc-pi`. After the first installation, already-running Pi panes need
+`/reload`. Diagnose an installation with `herdr integration status`.
+
 ---
 
 ## Neovim

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ It is a false positive — this repo has no web app. Ignore it.
 ## Install / apply changes
 
 ```sh
-./install.sh   # symlink every top-level item to ~/.<name>, set up nvim, install plugins
+./install.sh   # symlink top-level items, apply the explicit Omarchy allowlist, set up nvim, install plugins
 ```
 
 `install.sh` is the deployment mechanism and the key thing to understand:
@@ -33,9 +33,17 @@ It is a false positive — this repo has no web app. Ignore it.
 - It symlinks `herdr/config.toml` to `~/.config/herdr/config.toml` if that path is missing.
 - It symlinks `ssh/config` to `~/.ssh/config`. A pre-existing real file is backed up to
   `~/.ssh/config.pre-dotfiles`. Keys and `known_hosts` remain machine-local.
-- On Omarchy, it copies `omarchy/hypr/input.lua` to `~/.config/hypr/input.lua`.
-  Hyprland's Lua loader requires the module beneath its config root, so this file cannot
-  be an out-of-tree symlink. A differing destination is timestamp-backed up first.
+- On Omarchy, it copies only the explicit allowlist: `omarchy/hypr/input.lua` to
+  `~/.config/hypr/input.lua`, `omarchy/shell.json` to `~/.config/omarchy/shell.json`,
+  and `omarchy/XCompose` to `~/.XCompose`. Parent directories are created as needed.
+  Copies are regular files, not symlinks; identical regular destinations are skipped,
+  while differing files and symlinks are moved to timestamped backups before replacement.
+- XCompose includes Omarchy's default sequences and `include "%H/.XCompose.local"`.
+  An existing `~/.XCompose.local` is preserved. If it is absent, an empty mode-600 file
+  is created only when `~/.XCompose` is absent or already equals the tracked wrapper; a
+  differing destination with no local file is warned about and left untouched.
+- Stock-identical Omarchy files, monitor configuration, generated/themed files, and
+  Omarchy-installed first-run hooks remain unmanaged.
 
 ## Reload without reinstalling
 
@@ -43,6 +51,9 @@ It is a false positive — this repo has no web app. Ignore it.
 - Vim/Neovim: `:source ~/.vimrc`
 - tmux: `tmux source-file ~/.tmux.conf`
 - Herdr: `herdr server reload-config`
+- Hyprland input: `hyprctl reload`, then `hyprctl configerrors`
+- Omarchy shell: hot-reloads `~/.config/omarchy/shell.json`; force with `omarchy restart shell`
+- XCompose: `omarchy restart xcompose`
 
 ## Architecture
 
@@ -127,10 +138,24 @@ symlinks it to `~/.config/herdr/config.toml`. Prefix is `ctrl+a`. Completions li
 
 ### Omarchy
 
-`omarchy/hypr/input.lua` is copied to `~/.config/hypr/input.lua` only on Omarchy
-systems. It cannot be an out-of-tree symlink because Hyprland's Lua module loader
-requires the file beneath its config root. Validate changes with `hyprctl reload` and
-`hyprctl configerrors`. The tracked override maps Caps Lock to Ctrl with `ctrl:nocaps`.
+The installer manages this explicit allowlist only on Omarchy systems:
+
+- `omarchy/hypr/input.lua` → `~/.config/hypr/input.lua`
+- `omarchy/shell.json` → `~/.config/omarchy/shell.json`
+- `omarchy/XCompose` → `~/.XCompose`
+
+These files are copied beneath their live destinations because Hyprland's Lua module
+loader requires `input.lua` beneath its config root and the other overrides are also
+intended to be regular files. Identical regular files are no-ops; differing files and
+symlinks are moved to timestamped backups before replacement. The input override maps
+Caps Lock to Ctrl with `ctrl:nocaps`.
+
+The tracked XCompose wrapper includes Omarchy's default sequences and the private
+`include "%H/.XCompose.local"`. Existing local content is never overwritten. A local
+file is created empty with mode 600 only when absent and safe to initialize; if a local
+file is absent while an existing `~/.XCompose` differs from the wrapper, the installer
+warns and leaves that destination untouched. Stock-identical Omarchy files, monitor
+configuration, generated/themed files, and first-run hooks remain unmanaged.
 
 ### SSH
 
@@ -148,7 +173,8 @@ Use this shared machine inventory for remote operations. Confirm `hostname` and
 ## Conventions
 
 - Local, non-committed customization goes in `*.local` files (`~/.aliases.local`,
-  `~/.vimrc.local`, `~/.zshrc.local`, `~/.vimrc.bundles.local`), sourced only if present.
+  `~/.vimrc.local`, `~/.zshrc.local`, `~/.vimrc.bundles.local`, `~/.XCompose.local`),
+  sourced or included only if present.
   Put machine-specific secrets/paths there, not in the tracked files.
 - `mac` and `macos.txt` are opinionated, optional macOS system bootstrap (Homebrew, defaults).
   They are not run by `install.sh` — invoke `./mac` deliberately, only if wanted.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Personal shell, editor, tmux, and Herdr configuration with a bootstrap installer
 - [Key mappings and usage](#key-mappings-and-usage)
 - [tmux](#tmux)
 - [Herdr](#herdr)
+- [Omarchy configuration](#omarchy-configuration)
 - [Tailscale machine workflow](#tailscale-machine-workflow)
 - [Local machine overrides](#local-machine-overrides)
 - [Releases](#releases)
@@ -30,7 +31,10 @@ Personal shell, editor, tmux, and Herdr configuration with a bootstrap installer
 - `ssh/config`: tracked host aliases; installed as `~/.ssh/config` without managing private keys.
 - `docs/`: repository planning and decision records; it is intentionally not linked into `$HOME`.
 - `herdr/`: Herdr config; `install.sh` links `herdr/config.toml` to `~/.config/herdr/config.toml` instead of `~/.herdr`.
-- `omarchy/hypr/input.lua`: Omarchy keyboard overrides; copied to `~/.config/hypr/input.lua` on Omarchy systems.
+- `omarchy/`: an explicit allowlist of Omarchy user overrides copied on Omarchy systems:
+  - `hypr/input.lua` → `~/.config/hypr/input.lua`
+  - `shell.json` → `~/.config/omarchy/shell.json`
+  - `XCompose` → `~/.XCompose`, with private rules included from `~/.XCompose.local`
 
 ## Requirements
 
@@ -63,12 +67,14 @@ cd ~/dotfiles
 
 1. Fails before any home, plugin, or parser mutation unless `nvim` is available and reports 0.12+.
 1. Symlinks each top-level repo item to `$HOME` as a dotfile.
-1. Skips `install.sh`, `README.md`, the repository-only `docs/` planning directory, and `herdr/` (installed into XDG config, not `~/.herdr`).
+1. Skips `install.sh`, `README.md`, the repository-only `docs/` planning directory, `herdr/`, `omarchy/`, and `ssh/` from generic top-level symlinking.
 1. Warns (does not overwrite) if a destination exists and is not a symlink.
 1. Symlinks `ssh/config` to `~/.ssh/config`. If a real file is already there, it is moved to `~/.ssh/config.pre-dotfiles` first. Private keys remain unmanaged.
-1. On Omarchy, copies `omarchy/hypr/input.lua` to `~/.config/hypr/input.lua`; a differing existing file is timestamp-backed up first.
+1. On Omarchy, copies only the explicit allowlist: `omarchy/hypr/input.lua` to `~/.config/hypr/input.lua`, `omarchy/shell.json` to `~/.config/omarchy/shell.json`, and `omarchy/XCompose` to `~/.XCompose`. Parent directories are created as needed. Identical regular files are skipped; differing files and symlinks are moved to timestamped backups before replacement.
+1. For XCompose, preserves any existing `~/.XCompose.local`. If it is absent, an empty mode-600 file is created only when `~/.XCompose` is absent or already equals the tracked wrapper. If an existing `~/.XCompose` differs while the local file is absent, the installer warns and leaves it untouched.
 1. Creates `~/.config/nvim/init.vim` (if missing) with `source ~/.vimrc`.
 1. Symlinks `herdr/config.toml` to `~/.config/herdr/config.toml` if that path is missing.
+1. If `herdr` is available, installs the official Pi integration separately for each existing `~/.pi/agent` and `~/.arc-pi` directory; missing directories are skipped and failures warn without stopping the installer.
 1. Installs `vim-plug` for Neovim into:
    - `${XDG_DATA_HOME:-$HOME/.local/share}/nvim/site/autoload/plug.vim`
 1. Runs plugin install:
@@ -290,6 +296,13 @@ Herdr config is tracked as [`herdr/config.toml`](herdr/config.toml) and installe
 Prefix is `ctrl+a`. Detach with `Ctrl+a q`. Reload a running server with
 `herdr server reload-config`.
 
+Herdr automatically snapshots workspace, tab, and pane topology. Native
+agent-session resume requires current official integrations. This config enables
+it with `resume_agents_on_restore = true`. Normal Pi uses `~/.pi/agent`; ARC Pi
+uses `~/.arc-pi`. After the first installation, already-running Pi panes need
+`/reload` before they can use the integration. Diagnose an installation with
+`herdr integration status`.
+
 zsh completion is generated into [`zsh/completion/_herdr`](zsh/completion/_herdr)
 (`herdr completion zsh`). Re-source `~/.zshrc` (or open a new shell) after install.
 
@@ -342,18 +355,38 @@ Override the npm package if needed:
 T3_CODE_NPX_PACKAGE='actual-package@latest' npxt3
 ```
 
-## Omarchy keyboard
+## Omarchy configuration
 
-The tracked Omarchy input override maps Caps Lock to an additional Ctrl key with
-`kb_options = "ctrl:nocaps"`. It is copied rather than symlinked because Hyprland's
-Lua module loader requires the module beneath `~/.config/hypr`. Apply repository
-updates with `./install.sh`; a differing destination is backed up first. Hyprland
-applies changes automatically; validate them with:
+The installer manages only this Omarchy allowlist:
+
+- `omarchy/hypr/input.lua` → `~/.config/hypr/input.lua`
+- `omarchy/shell.json` → `~/.config/omarchy/shell.json`
+- `omarchy/XCompose` → `~/.XCompose`
+
+These are regular copies, not symlinks. Identical regular destinations are left
+alone. A differing file or any symlink is moved to a timestamped backup before the
+tracked copy replaces it. The tracked input override maps Caps Lock to an additional
+Ctrl key with `kb_options = "ctrl:nocaps"`.
+
+`XCompose` includes Omarchy's default compose sequences and the private local file
+with `include "%H/.XCompose.local"`. Existing local content is never overwritten.
+When that file is absent, the installer creates an empty mode-600 local file only if
+the destination is absent or already the tracked wrapper. If an existing destination
+differs while the local file is absent, it warns and leaves the destination untouched.
+
+Stock-identical Omarchy files, monitor configuration, generated/themed files, and
+Omarchy-installed first-run hooks remain unmanaged so Omarchy continues to own them.
+
+Apply repository updates with `./install.sh`. Hyprland applies input changes
+automatically; force a reload and validate it with:
 
 ```sh
 hyprctl reload
 hyprctl configerrors
 ```
+
+The Omarchy shell hot-reloads `shell.json`; use `omarchy restart shell` to force a
+reload. Apply XCompose changes with `omarchy restart xcompose`.
 
 ## Local machine overrides
 
@@ -364,6 +397,8 @@ Use local files for machine-specific customization:
 - `~/.vimrc.local`
 - `~/.zshrc.local` — sourced last by `zshrc`, so it can override anything above; put
   secrets and per-host tool setup here.
+- `~/.XCompose.local` — private XCompose rules included by the tracked Omarchy
+  wrapper; it is never tracked or overwritten by this repository.
 
 These are sourced conditionally if present.
 

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -1,4 +1,8 @@
+onboarding = false
 # Herdr is the multiplexer. Prefix is Ctrl+a (same chord as the old tmux config).
+
+[session]
+resume_agents_on_restore = true
 
 [ui]
 agent_panel_sort = "spaces"

--- a/install.sh
+++ b/install.sh
@@ -96,20 +96,54 @@ else
   ln -s "$ssh_source" "$ssh_config"
 fi
 
-if [ -f /etc/os-release ] && grep -q '^ID=omarchy$' /etc/os-release; then
-  mkdir -p "$HOME/.config/hypr"
-  hypr_input_source="$PWD/omarchy/hypr/input.lua"
-  hypr_input="$HOME/.config/hypr/input.lua"
-  if [ ! -e "$hypr_input" ] && [ ! -L "$hypr_input" ]; then
-    echo "Creating $hypr_input"
-    cp "$hypr_input_source" "$hypr_input"
-  elif [ -L "$hypr_input" ] || ! cmp -s "$hypr_input_source" "$hypr_input"; then
-    hypr_input_backup="$hypr_input.backup.$(date +%Y%m%d-%H%M%S)"
-    echo "Backing up $hypr_input to $hypr_input_backup"
-    cp -L "$hypr_input" "$hypr_input_backup"
-    rm "$hypr_input"
-    cp "$hypr_input_source" "$hypr_input"
+install_omarchy_copy() {
+  omarchy_source="$1"
+  omarchy_destination="$2"
+
+  if [ ! -e "$omarchy_destination" ] && [ ! -L "$omarchy_destination" ]; then
+    echo "Creating $omarchy_destination"
+    cp "$omarchy_source" "$omarchy_destination"
+  elif [ -L "$omarchy_destination" ] || [ ! -f "$omarchy_destination" ] || ! cmp -s "$omarchy_source" "$omarchy_destination"; then
+    omarchy_backup="$omarchy_destination.backup.$(date +%Y%m%d-%H%M%S)"
+    omarchy_backup_suffix=1
+    while [ -e "$omarchy_backup" ] || [ -L "$omarchy_backup" ]; do
+      omarchy_backup="$omarchy_destination.backup.$(date +%Y%m%d-%H%M%S).$omarchy_backup_suffix"
+      omarchy_backup_suffix=$((omarchy_backup_suffix + 1))
+    done
+    echo "Backing up $omarchy_destination to $omarchy_backup"
+    mv "$omarchy_destination" "$omarchy_backup"
+    cp "$omarchy_source" "$omarchy_destination"
   fi
+}
+
+install_omarchy_xcompose() {
+  omarchy_xcompose_source="$PWD/omarchy/XCompose"
+  omarchy_xcompose="$HOME/.XCompose"
+  omarchy_xcompose_local="$HOME/.XCompose.local"
+
+  if [ -e "$omarchy_xcompose_local" ] || [ -L "$omarchy_xcompose_local" ]; then
+    :
+  elif [ ! -e "$omarchy_xcompose" ] && [ ! -L "$omarchy_xcompose" ]; then
+    echo "Creating $omarchy_xcompose_local"
+    (umask 077 && : > "$omarchy_xcompose_local")
+    chmod 600 "$omarchy_xcompose_local"
+  elif [ -f "$omarchy_xcompose" ] && cmp -s "$omarchy_xcompose_source" "$omarchy_xcompose"; then
+    echo "Creating $omarchy_xcompose_local"
+    (umask 077 && : > "$omarchy_xcompose_local")
+    chmod 600 "$omarchy_xcompose_local"
+  else
+    echo "WARNING: $omarchy_xcompose_local is absent while $omarchy_xcompose differs from the tracked wrapper; leaving $omarchy_xcompose untouched." >&2
+    return 0
+  fi
+
+  install_omarchy_copy "$omarchy_xcompose_source" "$omarchy_xcompose"
+}
+
+if [ -f /etc/os-release ] && grep -q '^ID=omarchy$' /etc/os-release; then
+  mkdir -p "$HOME/.config/hypr" "$HOME/.config/omarchy"
+  install_omarchy_copy "$PWD/omarchy/hypr/input.lua" "$HOME/.config/hypr/input.lua"
+  install_omarchy_copy "$PWD/omarchy/shell.json" "$HOME/.config/omarchy/shell.json"
+  install_omarchy_xcompose
 fi
 
 mkdir -p "$HOME/.config/nvim"
@@ -126,6 +160,19 @@ if [ -e "$herdr_config" ] || [ -L "$herdr_config" ]; then
 else
   echo "Creating $herdr_config"
   ln -s "$PWD/herdr/config.toml" "$herdr_config"
+fi
+
+if command -v herdr >/dev/null 2>&1; then
+  for pi_agent_dir in "$HOME/.pi/agent" "$HOME/.arc-pi"; do
+    if [ ! -d "$pi_agent_dir" ]; then
+      continue
+    fi
+    if PI_CODING_AGENT_DIR="$pi_agent_dir" herdr integration install pi; then
+      :
+    else
+      echo "WARNING: Herdr Pi integration install failed for $pi_agent_dir." >&2
+    fi
+  done
 fi
 
 PLUG_PATH="${XDG_DATA_HOME:-$HOME/.local/share}/nvim/site/autoload/plug.vim"

--- a/omarchy/XCompose
+++ b/omarchy/XCompose
@@ -1,0 +1,7 @@
+# Run omarchy restart xcompose to apply changes.
+
+# Include Omarchy's default compose sequences.
+include "/usr/share/omarchy/default/xcompose"
+
+# Include private, machine-local compose rules.
+include "%H/.XCompose.local"

--- a/omarchy/shell.json
+++ b/omarchy/shell.json
@@ -1,0 +1,69 @@
+{
+  "version": 1,
+  "idle": {
+    "screensaver": 150,
+    "lock": 300
+  },
+  "bar": {
+    "position": "top",
+    "transparent": false,
+    "centerAnchor": "omarchy.clock",
+    "layout": {
+      "left": [
+        {
+          "id": "omarchy.menu"
+        },
+        {
+          "id": "omarchy.workspaces"
+        }
+      ],
+      "center": [
+        {
+          "id": "omarchy.indicators"
+        },
+        {
+          "id": "omarchy.clock",
+          "format": "dddd HH:mm",
+          "formatAlt": "d MMMM 'W'ww yyyy",
+          "verticalFormat": "HH\n—\nmm"
+        },
+        {
+          "id": "omarchy.keyboard-layout"
+        },
+        {
+          "id": "omarchy.weather"
+        },
+        {
+          "id": "omarchy.system-update"
+        }
+      ],
+      "right": [
+        {
+          "id": "omarchy.tray"
+        },
+        {
+          "id": "omarchy.tailscale"
+        },
+        {
+          "id": "omarchy.agents"
+        },
+        {
+          "id": "omarchy.bluetooth"
+        },
+        {
+          "id": "omarchy.network"
+        },
+        {
+          "id": "omarchy.audio"
+        },
+        {
+          "id": "omarchy.monitor"
+        },
+        {
+          "id": "omarchy.power"
+        }
+      ]
+    }
+  },
+  "plugins": []
+}


### PR DESCRIPTION
## Summary

- enable Herdr topology persistence and native Pi session resume
- install Herdr's official Pi integration for both normal Pi and ARC Pi directories
- manage an explicit Omarchy allowlist for Hypr input, shell layout, and a privacy-safe XCompose wrapper
- preserve private compose rules in untracked `~/.XCompose.local` and back up differing managed files
- document restore, integration, reload, and selective-config behavior

## Verification

- `sh -n install.sh`
- `git diff --check`
- `jq empty omarchy/shell.json`
- `herdr config check`
- isolated temporary-HOME installer tests for fresh install, backups, symlinks, XCompose conflict refusal, local-file preservation, and idempotency
- live XCompose service active and `hyprctl configerrors` clean
