### PR TITLE
feat: finish Herdr-only multiplexer cutover

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -10,7 +10,7 @@ Print-friendly one-pager. Regenerate or extend as your config changes.
 
 ```
 Terminal app (Ghostty / iTerm / etc.)
-  └─ herdr        multiplexer (prefix Ctrl+a)
+  └─ herdr        multiplexer (prefix Ctrl+a); one workspace per project
        └─ zsh     history, completion, aliases, shell functions
             └─ nvim   edit files, grep, LSP, Copilot, NERDTree
 ```
@@ -30,11 +30,11 @@ Terminal app (Ghostty / iTerm / etc.)
 | `Ctrl+R` | Search shell history |
 | `Ctrl+A` / `Ctrl+E` | Line start / end (shell) |
 | `Ctrl+Q` | Stash current line, run something else, pop it back |
-| `Ctrl+a` | herdr prefix |
-| `Ctrl+a` `v` / `-` | Split pane right / down |
-| `Ctrl+a` `h/j/k/l` | Move between herdr panes |
-| `Ctrl+a` `q` | Detach from herdr |
-| `Ctrl+a` `[` | herdr copy mode |
+| `Ctrl+a` | Herdr prefix |
+| `Ctrl+a` `-` / `v` | Split pane down / right |
+| `Ctrl+a` `h/j/k/l` | Move between Herdr panes |
+| `Ctrl+a` `q` | Detach from Herdr |
+| `Ctrl+a` `[` | Herdr copy mode |
 | `,` | Neovim leader |
 | `jk` | Leave insert mode (Neovim) |
 | `,,` | Toggle previous buffer |
@@ -45,7 +45,7 @@ Terminal app (Ghostty / iTerm / etc.)
 | `gh` | LSP hover (types/docs) in attached buffers |
 | `Ctrl+h/j/k/l` | Move between nvim splits |
 | `g` | `git status` (no args) or `git …` |
-| `tat` | Attach tmux session for current directory |
+| `tat` | Focus or create a Herdr workspace for this directory |
 | `mcd dirname` | `mkdir -p` and `cd` into it |
 
 ---
@@ -203,7 +203,7 @@ Machine-specific aliases: `~/.aliases.local`
 
 | Command | Action |
 |---------|--------|
-| `tat` | `tmux attach -t $(basename $PWD)` — session per directory |
+| `tat` | Focus or create a Herdr workspace for `$PWD` |
 | `replace old new files…` | Find/replace across files via `ag` + `sed` |
 | `git-churn` | Rank changed files by commit frequency vs `origin/main` |
 | `pi update` / `arc-pi update` | Update the mise-managed Pi installation |
@@ -222,62 +222,60 @@ T3_CODE_NPX_PACKAGE='actual-package@latest' npxt3
 
 ---
 
-## Tmux
+## Herdr
 
-**Prefix: `Ctrl+a`** (GNU Screen style, not default `Ctrl+b`).
+**Prefix: `Ctrl+a`**. Press prefix, release, then the second key. Config:
+`herdr/config.toml` → `~/.config/herdr/config.toml`. Live help: `Ctrl+a` `?`.
 
-Press prefix, release, then the second key — unless noted as a chord (`Ctrl+a` held).
+One default session per machine. Projects are **workspaces**, not named sessions.
+New panes inherit the current directory (`terminal.new_cwd = "follow"`).
 
-### Sessions
+SSH auto-attaches (`exec herdr`) unless `NO_AUTO_HERDR=1`, `NO_AUTO_TMUX=1`, or
+`HERDR_ENV=1`. If Herdr is missing, SSH stays a plain shell.
 
-| Keys | Action |
-|------|--------|
-| `tmux` | New session |
-| `tmux new -s name` | Named session |
-| `tmux ls` | List sessions |
-| `tmux attach -t name` | Attach |
-| `tat` | Attach to session named after `basename $PWD` |
-| `Ctrl+a` `d` | Detach |
-| `Ctrl+a` `$` | Rename session |
-| `Ctrl+a` `s` | Session picker |
-| `Ctrl+a` `(` / `)` | Previous / next session |
+Optional thin client from another Mac (does not replace SSH auto-attach):
 
-SSH auto-attaches to Herdr (`exec herdr`) unless `NO_AUTO_TMUX=1` or `HERDR_ENV=1`.
-Falls back to tmux `ssh-$HOST` if Herdr is not installed.
+```sh
+herdr --remote andrews-mac-mini
+herdr --remote qianas-macbook-pro
+```
 
-### Windows
+### Session and workspaces
 
 | Keys | Action |
 |------|--------|
-| `Ctrl+a` `c` | New window |
-| `Ctrl+a` `n` / `p` | Next / previous window |
-| `Ctrl+a` `0`–`9` | Jump to window number |
-| `Ctrl+a` `,` | Rename window |
-| `Ctrl+a` `&` | Kill window |
-| `Ctrl+a` `w` | Window list |
-| `Ctrl+a` `Ctrl+h` / `Ctrl+l` | Previous / next window |
-| `Ctrl+a` `Ctrl+j` | `choose-tree` (session/window tree) |
+| `herdr` | Attach (or start) the default session |
+| `tat` | Focus or create a workspace for `$PWD` |
+| `Ctrl+a` `q` | Detach (panes keep running) |
+| `Ctrl+a` `w` | Workspace picker |
+| `Ctrl+a` `g` | Goto picker |
+| `Ctrl+a` `Shift+n` | New workspace |
+| `Ctrl+a` `Shift+w` | Rename workspace |
+| `herdr server reload-config` | Reload `config.toml` |
+| `Ctrl+a` `Shift+r` | Reload config (prefix+r is resize mode) |
 
-Windows are 1-indexed and renumber after closes.
+### Tabs
+
+| Keys | Action |
+|------|--------|
+| `Ctrl+a` `c` | New tab |
+| `Ctrl+a` `n` / `p` | Next / previous tab |
+| `Ctrl+a` `1`–`9` | Jump to tab number |
+| `Ctrl+a` `Shift+t` | Rename tab |
+| `Ctrl+a` `Shift+x` | Close tab |
 
 ### Panes
 
 | Keys | Action |
 |------|--------|
-| `Ctrl+a` `"` or `-` | Split horizontal (current path) |
-| `Ctrl+a` `%` or `\` or `\|` | Split vertical (current path) |
-| `Ctrl+a` `h` `j` `k` `l` | Move to pane (vi-style) |
-| `Ctrl+a` `Ctrl+a` | Toggle last pane |
-| `Ctrl+a` `o` | Cycle panes |
-| `Ctrl+a` `;` | Toggle last pane (default) |
-| `Ctrl+a` `x` | Kill pane |
-| `Ctrl+a` `!` | Move pane to new window |
-| `Ctrl+a` `b` | Break pane into new window |
-| `Ctrl+a` `+` | Zoom / unzoom pane |
-| `Ctrl+a` `=` | Tile all panes |
-| `Ctrl+a` `↑↓←→` | Resize pane (your config: 4–8 cells) |
-| `Ctrl+a` `q` | Show pane numbers, then jump |
-| `Ctrl+a` `{` / `}` | Swap pane with previous / next |
+| `Ctrl+a` `-` | Split down |
+| `Ctrl+a` `v` or `%` or `\|` | Split right |
+| `Ctrl+a` `h` `j` `k` `l` | Move to pane |
+| `Ctrl+a` `;` | Last pane |
+| `Ctrl+a` `x` | Close pane |
+| `Ctrl+a` `z` or `+` | Zoom / unzoom |
+| `Ctrl+a` `r` | Resize mode |
+| `Ctrl+a` `Shift+h/j/k/l` | Swap pane |
 
 ### Copy mode (vi keys)
 
@@ -286,54 +284,16 @@ Windows are 1-indexed and renumber after closes.
 | `Ctrl+a` `[` | Enter copy mode |
 | `h` `j` `k` `l` | Move |
 | `w` / `b` / `e` | Word motion |
-| `g` / `G` | Top / bottom |
-| `/` / `?` | Search forward / backward |
 | `v` | Begin selection |
-| `y` or `Enter` | Copy to macOS clipboard |
-| `q` | Quit copy mode |
-| `Esc` | Quit copy mode |
+| `y` or `Enter` | Copy to clipboard |
+| `q` / `Esc` | Quit copy mode |
 
-### Your custom tmux keys
+Mouse drag-select also copies. Agents (pi, Claude, Cursor Agent) resume after a
+Herdr server restart when official integrations are installed
+(`herdr integration status`).
 
-| Keys | Action |
-|------|--------|
-| `Ctrl+a` `r` | Reload `~/.tmux.conf` |
-| `Ctrl+a` `m` | Mouse on |
-| `Ctrl+a` `M` | Mouse off |
-| `Ctrl+a` `a` | Send literal `Ctrl+a` to app |
-
-### tmux-resurrect + continuum (installed)
-
-| Keys | Action |
-|------|--------|
-| `Ctrl+a` `Ctrl+s` | Save session |
-| `Ctrl+a` `Ctrl+r` | Restore session |
-
-Continuum autosaves about every **60 minutes** and restores the last save when the
-tmux server starts. Save also records pi / Claude / Cursor agent session IDs so
-restore relaunches with `--session` or `--resume`. Debug mapping:
-`tmux-agent-sessions status` (writes `~/.tmux/resurrect/agent-sessions.tsv` on save).
-
-### Host status bar colors (Tailscale SSH)
-
-| Host | Bar color |
-|------|-----------|
-| `andrews-mac-mini` | Green |
-| `qianas-macbook-pro` | Blue |
-| Other hosts | Yellow |
-
----
-
-## Herdr
-
-Multiplexer. Prefix is `Ctrl+a`. Config: `herdr/config.toml` → `~/.config/herdr/config.toml`.
-
-| Keys | Action |
-|------|--------|
-| `herdr` | Attach (or start) the default session |
-| `Ctrl+a` `q` | Detach Herdr (panes keep running) |
-| `Ctrl+a` `?` | Show live keybindings |
-| `herdr server reload-config` | Reload `config.toml` |
+`tmux.conf` is still in the repo as a soak-period emergency hatch. Do not nest
+tmux inside Herdr.
 
 Herdr automatically snapshots workspace, tab, and pane topology. Native
 agent-session resume requires current official integrations. This config enables
@@ -624,8 +584,7 @@ Conventional commit types (for `semantic-release`): `feat:`, `fix:`, `chore:`, `
 | What | Command |
 |------|---------|
 | zsh | `source ~/.zshrc` |
-| tmux | `tmux source-file ~/.tmux.conf` or `Ctrl+a` `r` |
-| Herdr | `herdr server reload-config` |
+| Herdr | `herdr server reload-config` or `Ctrl+a` `Shift+r` |
 | nvim | `:source ~/.vimrc` or `,sv` (also runs `:Sleuth`) |
 | Full dotfiles symlink | `./install.sh` from repo root |
 
@@ -635,7 +594,8 @@ Conventional commit types (for `semantic-release`): `feat:`, `fix:`, `chore:`, `
 
 | Variable | Effect |
 |----------|--------|
-| `NO_AUTO_TMUX=1` | Skip SSH auto-attach to Herdr (or tmux fallback) |
+| `NO_AUTO_HERDR=1` | Skip SSH auto-attach to Herdr (plain remote shell) |
+| `NO_AUTO_TMUX=1` | Same escape hatch as `NO_AUTO_HERDR` (legacy name) |
 | `HERDR_ENV=1` | Set by Herdr in its panes; also skips SSH auto-attach |
 | `DOTFILES_NERD_FONT=0` | ASCII-safe NERDTree arrows (no icon font) |
 | `T3_CODE_NPX_PACKAGE` | Override package for `npxt3` |
@@ -662,8 +622,9 @@ Use a **Nerd Font** (e.g. Hack Nerd Font) for devicons in nvim unless `DOTFILES_
 
 ```sh
 ssh mini                                  # auto-attaches this machine's Herdr session
-ssh macbook                               # Herdr if installed, else tmux (blue bar)
-ssh -t macbook 'NO_AUTO_TMUX=1 exec zsh -l' # plain shell, no Herdr/tmux
+ssh macbook                               # auto-attaches that machine's Herdr session
+ssh -t macbook 'NO_AUTO_HERDR=1 exec zsh -l' # plain shell, no Herdr
+herdr --remote andrews-mac-mini           # optional local thin client
 ```
 
 After dotfiles install on a remote Mac: `./install.sh`, then `source ~/.zshrc`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-Personal dotfiles for zsh, Vim/Neovim, tmux, and Herdr, deployed to `$HOME` by a symlink-based
+Personal dotfiles for zsh, Vim/Neovim, and Herdr, deployed to `$HOME` by a symlink-based
 installer. There is no build or test suite — "running" a change means re-sourcing the
 relevant config and confirming it loads without error.
 
@@ -28,6 +28,8 @@ It is a false positive — this repo has no web app. Ignore it.
 - It **never overwrites** top-level `~/.<name>` targets: if the destination already exists
   and is not a symlink, it only warns. Existing symlinks are left untouched. To re-link
   after renaming, remove the old symlink manually.
+- If `~/.bin` already exists as a directory, it still links each executable from `bin/`
+  into `~/.bin/` (PATH comes from `zsh/configs/post/path.zsh`).
 - It writes `~/.config/nvim/init.vim` (containing `source ~/.vimrc`) so Neovim reuses the
   Vim config, installs `vim-plug`, then runs `PlugInstall --sync`.
 - It symlinks `herdr/config.toml` to `~/.config/herdr/config.toml` if that path is missing.
@@ -49,7 +51,6 @@ It is a false positive — this repo has no web app. Ignore it.
 
 - zsh: `source ~/.zshrc`
 - Vim/Neovim: `:source ~/.vimrc`
-- tmux: `tmux source-file ~/.tmux.conf`
 - Herdr: `herdr server reload-config`
 - Hyprland input: `hyprctl reload`, then `hyprctl configerrors`
 - Omarchy shell: hot-reloads `~/.config/omarchy/shell.json`; force with `omarchy restart shell`
@@ -108,23 +109,18 @@ bin/generate-vim-plugin-inventory
 `aliases` is a separate top-level file (→ `~/.aliases`) and is Ruby/Rails-era; it sources
 `~/.aliases.local` for machine-specific additions.
 
-### tmux
-
-`tmux.conf` (→ `~/.tmux.conf`) with prefix remapped to `Ctrl+a`, vi-style pane navigation,
-and TPM-managed plugins (`tpm`, `tmux-sensible`, `tmux-resurrect`, `tmux-battery`).
-`.tmux/` holds TPM itself.
-
-SSH shells attach to Herdr through `zsh/configs/post/ssh-herdr.zsh` (`exec herdr`)
-unless `NO_AUTO_TMUX=1` or `HERDR_ENV=1` is set. If Herdr is missing, they fall
-back to tmux (`ssh-$HOST`). The tmux status bar is host-color-coded for known
-Tailscale Macs: `andrews-mac-mini` / `Andrews-Mac-mini` is green,
-`qianas-macbook-pro` is blue, and unknown hosts are yellow.
-
 ### Herdr
 
 `herdr/config.toml` is repository-only at the top level (not `~/.herdr`). `install.sh`
 symlinks it to `~/.config/herdr/config.toml`. Prefix is `ctrl+a`. Completions live in
 `zsh/completion/_herdr`.
+
+SSH shells attach to Herdr through `zsh/configs/post/ssh-herdr.zsh` (`exec herdr`)
+unless `NO_AUTO_HERDR=1`, `NO_AUTO_TMUX=1`, or `HERDR_ENV=1` is set. If Herdr is
+missing, SSH stays a plain shell.
+
+`tmux.conf` is still tracked as a soak-period emergency hatch. Do not nest tmux
+inside Herdr.
 
 ### bin/ utilities (on PATH)
 
@@ -132,7 +128,7 @@ symlinks it to `~/.config/herdr/config.toml`. Prefix is `ctrl+a`. Completions li
 - `pi` — forward normal commands to mise-managed Pi; translate Pi self-updates to
   `mise upgrade pi`, including updates requested through ARC Pi.
 - `npxt3` — run T3 Code through `npx -y ${T3_CODE_NPX_PACKAGE:-t3@latest}`.
-- `tat` — attach/create a tmux session named after the current directory.
+- `tat` — focus or create a Herdr workspace for the current directory.
 - `git-churn` — rank files by commit frequency.
 - `replace` — project-wide find/replace helper.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dotfiles
 
-Personal shell, editor, tmux, and Herdr configuration with a bootstrap installer.
+Personal shell, editor, and Herdr configuration with a bootstrap installer.
 
 ## Contents
 
@@ -12,8 +12,8 @@ Personal shell, editor, tmux, and Herdr configuration with a bootstrap installer
 - [Neovim and Vim](#neovim-and-vim)
 - [Plugin management](#plugin-management)
 - [Key mappings and usage](#key-mappings-and-usage)
-- [tmux](#tmux)
 - [Herdr](#herdr)
+- [tmux (emergency hatch)](#tmux-emergency-hatch)
 - [Omarchy configuration](#omarchy-configuration)
 - [Tailscale machine workflow](#tailscale-machine-workflow)
 - [Local machine overrides](#local-machine-overrides)
@@ -26,7 +26,7 @@ Personal shell, editor, tmux, and Herdr configuration with a bootstrap installer
 - `zshrc` and `zsh/`: shell options, prompt, completions, and shell helpers.
 - `aliases`: command aliases for git/workflow shortcuts.
 - `vimrc*` and `vim/`: Vim + Neovim settings and plugin config.
-- `tmux.conf` and `.tmux/`: tmux behavior and TPM plugin setup.
+- `tmux.conf` and `.tmux/`: leftover tmux config kept only as a soak-period emergency hatch; daily multiplexing is Herdr.
 - `bin/`: utility scripts (`git-churn`, `replace`, `tat`, etc).
 - `ssh/config`: tracked host aliases; installed as `~/.ssh/config` without managing private keys.
 - `docs/`: repository planning and decision records; it is intentionally not linked into `$HOME`.
@@ -72,6 +72,7 @@ cd ~/dotfiles
 1. Symlinks `ssh/config` to `~/.ssh/config`. If a real file is already there, it is moved to `~/.ssh/config.pre-dotfiles` first. Private keys remain unmanaged.
 1. On Omarchy, copies only the explicit allowlist: `omarchy/hypr/input.lua` to `~/.config/hypr/input.lua`, `omarchy/shell.json` to `~/.config/omarchy/shell.json`, and `omarchy/XCompose` to `~/.XCompose`. Parent directories are created as needed. Identical regular files are skipped; differing files and symlinks are moved to timestamped backups before replacement.
 1. For XCompose, preserves any existing `~/.XCompose.local`. If it is absent, an empty mode-600 file is created only when `~/.XCompose` is absent or already equals the tracked wrapper. If an existing `~/.XCompose` differs while the local file is absent, the installer warns and leaves it untouched.
+1. If `~/.bin` is already a real directory (not a symlink to `bin/`), links each executable from `bin/` into `~/.bin/` so `tat` and the other PATH utilities resolve.
 1. Creates `~/.config/nvim/init.vim` (if missing) with `source ~/.vimrc`.
 1. Symlinks `herdr/config.toml` to `~/.config/herdr/config.toml` if that path is missing.
 1. If `herdr` is available, installs the official Pi integration separately for each existing `~/.pi/agent` and `~/.arc-pi` directory; missing directories are skipped and failures warn without stopping the installer.
@@ -245,56 +246,21 @@ call nerdcommenter#Comment('x', 'toggle')
 - `<leader>x`: save and quit
 - `<leader>q`: quit
 
-## tmux
-
-### Prefix
-
-Prefix is `Ctrl+a` (default `Ctrl+b` is unbound).
-
-### Useful behavior
-
-- Vim-like pane navigation with `h/j/k/l`
-- Split windows in current pane path
-- Mouse toggle:
-  - `prefix + m` enables mouse
-  - `prefix + M` disables mouse
-- Copy mode uses vi keys and copies to macOS clipboard via `reattach-to-user-namespace` when available.
-
-### Plugins
-
-Configured with TPM:
-
-- `tmux-plugins/tpm`
-- `tmux-plugins/tmux-sensible`
-- `tmux-plugins/tmux-resurrect` (save hook records pi/claude/agent session IDs for resume)
-- `tmux-plugins/tmux-battery`
-
-### Host colors and SSH auto-attach
-
-Known Tailscale Macs get host-specific tmux status colors:
-
-- `andrews-mac-mini` / `Andrews-Mac-mini`: green
-- `qianas-macbook-pro`: blue
-- Unknown hosts: yellow
-
-Interactive SSH shells attach to the host's Herdr session via
-[`zsh/configs/post/ssh-herdr.zsh`](zsh/configs/post/ssh-herdr.zsh) (`exec herdr`).
-If Herdr is not installed, they fall back to a tmux session named `ssh-$HOST`.
-Skipped when `NO_AUTO_TMUX=1` or when the shell is already inside Herdr
-(`HERDR_ENV=1`). Bypass for one session by setting the variable on the remote shell:
-
-```sh
-ssh -t mini 'NO_AUTO_TMUX=1 exec zsh -l'
-```
-
 ## Herdr
 
-Herdr config is tracked as [`herdr/config.toml`](herdr/config.toml) and installed to
-`~/.config/herdr/config.toml`. The top-level `herdr/` directory is not symlinked to
-`~/.herdr`.
+Herdr is the terminal multiplexer. Config is tracked as
+[`herdr/config.toml`](herdr/config.toml) and installed to
+`~/.config/herdr/config.toml`. The top-level `herdr/` directory is not
+symlinked to `~/.herdr`.
 
-Prefix is `ctrl+a`. Detach with `Ctrl+a q`. Reload a running server with
-`herdr server reload-config`.
+Prefix is `Ctrl+a`. Detach with `Ctrl+a q`. Reload a running server with
+`herdr server reload-config` or `Ctrl+a Shift+r` (`Ctrl+a r` is resize mode).
+A prefix change may need `herdr server stop` followed by `herdr` rather than
+reload alone. Last pane is `Ctrl+a ;` because `Ctrl+a Ctrl+a` sends a literal
+prefix.
+
+`tat` focuses an existing workspace for `$PWD` (pane cwd or basename label) or
+creates one. One default session per machine; use workspaces for projects.
 
 Herdr automatically snapshots workspace, tab, and pane topology. Native
 agent-session resume requires current official integrations. This config enables
@@ -305,6 +271,30 @@ uses `~/.arc-pi`. After the first installation, already-running Pi panes need
 
 zsh completion is generated into [`zsh/completion/_herdr`](zsh/completion/_herdr)
 (`herdr completion zsh`). Re-source `~/.zshrc` (or open a new shell) after install.
+
+Interactive SSH shells attach to the host's Herdr session via
+[`zsh/configs/post/ssh-herdr.zsh`](zsh/configs/post/ssh-herdr.zsh) (`exec herdr`).
+Skipped when `NO_AUTO_HERDR=1`, `NO_AUTO_TMUX=1`, or when the shell is already
+inside Herdr (`HERDR_ENV=1`). If Herdr is not installed, SSH stays a plain
+shell. Bypass for one session with:
+
+```sh
+ssh -t mini 'NO_AUTO_HERDR=1 exec zsh -l'
+```
+
+Optional local thin client (does not replace SSH auto-attach):
+
+```sh
+herdr --remote andrews-mac-mini
+herdr --remote qianas-macbook-pro
+```
+
+## tmux (emergency hatch)
+
+`tmux.conf` remains in the repo until the Herdr-only soak is done. Do not nest
+tmux inside Herdr. To roll back to tmux, check out the last commit that treated
+tmux as daily config and run `tmux source-file ~/.tmux.conf`. Leave the Homebrew
+`tmux` formula installed.
 
 ## Tailscale machine workflow
 
@@ -333,7 +323,6 @@ To apply these dotfiles on another Mac:
 cd ~/dotfiles
 git pull --ff-only
 ./install.sh
-tmux source-file ~/.tmux.conf
 herdr server reload-config
 ```
 
@@ -502,19 +491,26 @@ zsh -lic 'nvim --headless -u ~/.vimrc.bundles "+lua require(\"nvim-treesitter\")
   or report that local ESLint has no config.
 - In untrusted checkouts, run `:DotfilesTypeScriptLintDisable` before saving.
 
-### tmux keybindings not applying
+### Herdr keybindings not applying
 
 Ensure config is linked:
 
 ```sh
-ln -s ~/dotfiles/tmux.conf ~/.tmux.conf
+ln -s ~/dotfiles/herdr/config.toml ~/.config/herdr/config.toml
 ```
 
-Reload tmux config:
+Reload:
 
 ```sh
-tmux source-file ~/.tmux.conf
+herdr server reload-config
 ```
+
+A prefix change may require restarting the server (`herdr server stop`, then
+`herdr`) rather than reload alone.
+
+If interactive SSH does not attach Herdr, confirm `herdr` is on PATH or at
+`~/.local/bin/herdr`. Missing Herdr now leaves a plain shell instead of falling
+back to tmux.
 
 ## Optional macOS bootstrap
 

--- a/bin/tat
+++ b/bin/tat
@@ -1,6 +1,90 @@
 #!/bin/sh
 #
-# Attach to tmux session named the same as current directory.
+# Focus or create a Herdr workspace for the current directory.
+# Matches an existing workspace by pane cwd, then by label == basename($PWD).
+# Outside Herdr, attaches after ensuring the workspace exists.
 #
+set -eu
 
-tmux attach -t `basename $PWD`
+label="$(basename "$PWD")"
+cwd="$(pwd -P 2>/dev/null || pwd)"
+
+herdr_bin=""
+if command -v herdr >/dev/null 2>&1; then
+  herdr_bin="$(command -v herdr)"
+elif [ -x "$HOME/.local/bin/herdr" ]; then
+  herdr_bin="$HOME/.local/bin/herdr"
+else
+  echo "tat: herdr not found on PATH or in ~/.local/bin" >&2
+  exit 1
+fi
+
+ensure_server() {
+  if "$herdr_bin" status server >/dev/null 2>&1; then
+    return 0
+  fi
+  "$herdr_bin" server >/dev/null 2>&1 &
+  i=0
+  while [ "$i" -lt 50 ]; do
+    if "$herdr_bin" status server >/dev/null 2>&1; then
+      return 0
+    fi
+    i=$((i + 1))
+    sleep 0.1
+  done
+  echo "tat: herdr server did not start" >&2
+  exit 1
+}
+
+ensure_server
+
+workspace_id="$(
+  LABEL="$label" CWD="$cwd" HERDR="$herdr_bin" python3 - <<'PY'
+import json, os, subprocess, sys
+
+herdr = os.environ["HERDR"]
+label = os.environ["LABEL"]
+cwd = os.path.realpath(os.environ["CWD"])
+
+def load(args):
+    raw = subprocess.check_output([herdr, *args], text=True)
+    return json.loads(raw)
+
+try:
+    listed = load(["workspace", "list"])
+except subprocess.CalledProcessError:
+    sys.exit(0)
+
+workspaces = listed.get("result", {}).get("workspaces") or []
+label_hit = None
+for workspace in workspaces:
+    workspace_id = workspace.get("workspace_id") or ""
+    if not workspace_id:
+        continue
+    if workspace.get("label") == label and label_hit is None:
+        label_hit = workspace_id
+    try:
+        panes = load(["pane", "list", "--workspace", workspace_id])
+    except subprocess.CalledProcessError:
+        continue
+    for pane in panes.get("result", {}).get("panes") or []:
+        pane_cwd = pane.get("foreground_cwd") or pane.get("cwd") or ""
+        if pane_cwd and os.path.realpath(pane_cwd) == cwd:
+            print(workspace_id)
+            sys.exit(0)
+if label_hit:
+    print(label_hit)
+PY
+)"
+
+if [ -n "$workspace_id" ]; then
+  "$herdr_bin" workspace focus "$workspace_id" >/dev/null
+else
+  "$herdr_bin" workspace create --cwd "$cwd" --label "$label" --focus >/dev/null
+fi
+
+# Attach only from a bare terminal. Skip when already in Herdr, or still inside
+# leftover tmux (nested-tmux soak), so we do not exec a nested client.
+if [ -z "${HERDR_ENV:-}" ] && [ -z "${TMUX:-}" ]; then
+  exec "$herdr_bin"
+fi

--- a/docs/herdr-full-migration-IMPLEMENTATION_PLAN.md
+++ b/docs/herdr-full-migration-IMPLEMENTATION_PLAN.md
@@ -1,0 +1,296 @@
+# Herdr Full-Time Migration Implementation Plan
+
+**Work item:** `herdr-full-migration` (standalone request; no tracked issue)
+**Mode:** Gap plan — Herdr is already installed, configured, and used as the SSH outer multiplexer, but daily panes still run inside nested tmux.
+**Status:** In flight — Mac mini tmux cutover done; brew-services login residency and MacBook remain. Soak before deleting `tmux.conf`.
+**Suggested branch:** `feat/herdr-full-migration`
+**Plan date:** 2026-08-21
+
+## 1. Product goal and scope boundaries
+
+### Product goal
+
+Make Herdr the only terminal multiplexer on both Tailscale Macs, with no nested `tmux attach` in the daily path:
+
+- One Herdr session per machine, with one workspace per project.
+- Prefix and pane/tab muscle memory that replace the current tmux `Ctrl+a` workflow.
+- SSH login still lands in the host's live Herdr session.
+- Agent panes (pi, Claude Code, Cursor Agent) survive detach natively, and survive Herdr server restart through official integrations rather than `tmux-resurrect`.
+- Dotfiles, cheatsheet, and agent skills describe Herdr only. tmux remains an emergency binary at most, not a configured layer.
+
+### In scope
+
+- Hand-merge a tmux2herdr dry-run into tracked `herdr/config.toml` (never overwrite blindly).
+- Rebind Herdr from the nested-tmux `ctrl+b` prefix to the tmux muscle-memory prefix `ctrl+a`.
+- Rewrite `bin/tat` to focus-or-create a Herdr workspace for `$PWD`.
+- Remove the SSH tmux fallback once both Macs have a working Herdr binary.
+- Enable login-time Herdr server residency (`brew services start herdr`) as the continuum replacement.
+- Verify official Herdr integrations for the agents actually used here.
+- Update `README.md`, `CHEATSHEET.md`, `CLAUDE.md`, and `.agents/skills/tailscale-machine-ops/SKILL.md`.
+- After a soak period, stop tracking `tmux.conf` / `.tmux/` / `bin/tmux-agent-sessions` as active config.
+
+### Scope boundaries
+
+- Do not convert a live nested tmux session into Herdr panes. Herdr cannot inherit tmux PTYs. Cutover recreates workspaces and relaunches agents.
+- Do not uninstall the Homebrew `tmux` formula in the first shipping PR. Keep the binary as an emergency hatch until both Macs have soaked on Herdr-only.
+- Do not enable `experimental.pane_history` (saves pane output, including secrets) unless explicitly requested later.
+- Do not enable `experimental.allow_nested`.
+- Do not change Neovim, zsh vi-mode, aliases, or install.sh's Neovim/plugin path except where they mention tmux/Herdr.
+- Do not SSH to or mutate `qianas-macbook-pro` without explicit authorization.
+- Do not add Herdr plugins, herdr-spreader layouts, or a second named Herdr session unless a later need appears.
+- Do not treat `tmux2herdr` as the source of truth for keys that only exist to keep nested tmux alive.
+
+## 2. Recommended decisions (confirm before coding)
+
+These are the defaults this plan will implement unless the approval reply changes them.
+
+1. **Leave nested tmux. Recreate panes in Herdr.** There is no live-session importer. Snapshot current tmux windows first, then stop using `tmux attach` inside Herdr.
+2. **One default Herdr session per machine; projects are workspaces, not named sessions.** Named Herdr sessions stay unused. `tat` becomes "focus or create the workspace for this directory."
+3. **Move the Herdr prefix to `ctrl+a` once tmux is no longer nested.** That restores current tmux muscle memory. Keep `prefix+a` / `prefix+prefix` as send-literal-prefix so remote shells and nested TUIs still work.
+4. **Prefer Herdr defaults for keys that tmux only customized around plugins.** Map the daily set (splits, hjkl, tabs, zoom, copy mode, detach, reload). Drop mouse toggle keys (`m`/`M`), TPM reload, continuum save/restore chords, and `reattach-to-user-namespace`.
+5. **Replace resurrect/continuum with Herdr server residency + native agent restore.** `brew services start herdr` at login. Keep `[session].resume_agents_on_restore = true`. Install/upgrade official integrations for pi, Claude Code, and Cursor Agent. Delete `bin/tmux-agent-sessions` after that path is verified.
+6. **Keep the current SSH path:** interactive SSH still `exec herdr` on the remote host. Document `herdr --remote <host>` as an optional thin-client alternative; do not switch the auto-attach script to it.
+7. **Drop host-colored tmux status bars.** Herdr already sets the outer window title to `{hostname}: {workspace}`. Add a hostname token on the tab bar if it is not already visible. Per-host accent colors are out of scope unless Herdr grows a hostname-conditional overlay (unknown today; one tracked `config.toml` cannot `if-shell` the way `tmux.conf` does).
+8. **Keep `NO_AUTO_TMUX=1` as the documented escape hatch** and also honor `NO_AUTO_HERDR=1` with the same meaning.
+9. **Keep `tmux.conf` in the repo until Phase 5.** Existing `~/.tmux.conf` symlinks stay until cutover is verified on both Macs.
+
+## 3. Current baseline
+
+Repository evidence:
+
+- `herdr/config.toml` is nested-tmux phase only: `[ui] mouse_capture = true`, `[keys] prefix = "ctrl+b"`, plus a comment forbidding tmux2herdr until panes live in Herdr.
+- `install.sh` skips top-level `herdr/` and symlinks `herdr/config.toml` → `~/.config/herdr/config.toml`.
+- `zsh/configs/post/ssh-herdr.zsh` already `exec herdr` on interactive SSH when `TMUX`, `HERDR_ENV`, and `NO_AUTO_TMUX` are unset. tmux `ssh-$HOST` is still the fallback.
+- `zsh/completion/_herdr` is tracked.
+- `tmux.conf` is still the real multiplexer config: prefix `C-a`, vi pane keys, current-path splits, copy-pipe to pbcopy, host-colored status, TPM plugins (`sensible`, `resurrect`, `battery`, `continuum`), and a post-save hook into `bin/tmux-agent-sessions`.
+- `bin/tat` is `tmux attach -t $(basename $PWD)` and does not create a missing session.
+- `bin/tmux-agent-sessions` rewrites resurrect snapshots so pi / Claude / Cursor Agent relaunch with `--session` / `--resume`.
+- Docs (`README.md`, `CHEATSHEET.md`, `CLAUDE.md`, tailscale skill) still describe the nested stack: Herdr outer, tmux inner.
+
+Live-machine facts that are `unknown` until Phase 1 records them:
+
+- Installed Herdr version on `andrews-mac-mini` and `qianas-macbook-pro`.
+- Whether `brew services` already starts Herdr at login.
+- `herdr integration status` for pi / claude / cursor-agent.
+- The current nested tmux window/pane inventory (must be dumped at cutover; it is not in git).
+- Whether the MacBook already has `~/.config/herdr/config.toml` linked from this repo.
+
+## 4. Missing capabilities
+
+| Current tmux behavior | Herdr target | Gap |
+|---|---|---|
+| Nested `tmux attach` inside Herdr | Panes are Herdr panes | Daily workflow still nested |
+| Prefix `Ctrl+a` | `[keys] prefix = "ctrl+a"` | Tracked config still `ctrl+b` |
+| `tat` → tmux session named after cwd | `tat` focuses or creates a Herdr workspace for `$PWD` | `bin/tat` still calls tmux |
+| Continuum hourly save + restore on tmux start | `brew services start herdr` + snapshot restore | Not documented or configured in dotfiles |
+| `tmux-agent-sessions` rewrite of resurrect pane commands | `[session] resume_agents_on_restore` + official integrations | Custom script is tmux-only |
+| SSH fallback to `tmux new-session -A -s ssh-$HOST` | Fail closed to a plain shell, or require Herdr | Fallback still present |
+| Host-colored status bar | Window title / tab-bar hostname | No Herdr equivalent planned |
+| Battery in status-right | None | Deferred |
+| Mouse toggle `prefix m/M` | `[ui] mouse_capture = true` always | Toggle keys not needed |
+| Copy-pipe via `reattach-to-user-namespace` | Native Herdr copy mode / mouse drag | tmux-only |
+| Docs describe two multiplexers | Docs describe Herdr only | README / CHEATSHEET / CLAUDE.md / skill |
+
+Capability map for the daily key set (tmux → Herdr after prefix moves to `ctrl+a`):
+
+| Habit | tmux now | Herdr after cutover |
+|---|---|---|
+| Prefix | `Ctrl+a` | `Ctrl+a` |
+| Detach | `Ctrl+a d` | `Ctrl+a q` |
+| Split down | `Ctrl+a "` or `-` | `Ctrl+a -` (bind `"` too if the dry-run does not) |
+| Split right | `Ctrl+a %` `\` `\|` | `Ctrl+a v` plus keep `\` / `\|` if wanted |
+| Move panes | `Ctrl+a h/j/k/l` | `Ctrl+a h/j/k/l` (Herdr default) |
+| New tab | `Ctrl+a c` | `Ctrl+a c` |
+| Next/prev tab | `Ctrl+a n/p` | `Ctrl+a n/p` |
+| Zoom | `Ctrl+a +` | `Ctrl+a z` (Herdr default; rebind `+` only if muscle memory wins) |
+| Copy mode | `Ctrl+a [` then `v`/`y` | `Ctrl+a [` then `v`/`y`/`Enter` (native clipboard) |
+| Reload config | `Ctrl+a r` | Keep `Ctrl+a r` as reload if it does not steal Herdr resize mode; otherwise `Ctrl+a Shift+r` and document it |
+| Last pane | `Ctrl+a Ctrl+a` | Bind `keys.last_pane` if the action exists in this Herdr version; else document `prefix+;` / picker |
+| Send prefix | `Ctrl+a a` | `Ctrl+a a` and/or `Ctrl+a Ctrl+a` |
+| Workspace picker | tmux session tree `Ctrl+a Ctrl+j` | `Ctrl+a w` / `Ctrl+a g` |
+| Help | none | `Ctrl+a ?` |
+
+## 5. Milestones / phases
+
+### Phase 1 - Inventory the live nested setup and confirm decisions
+
+**Goals:** Record what actually has to survive cutover. Confirm the decision list in section 2. Do not change tracked config yet.
+
+**Deliverables:**
+
+- A cutover note (can live in the progress file) with: `herdr --version`, `herdr status`, `herdr integration status`, `brew services list | grep herdr`, `tmux ls`, and `tmux list-windows -a` from the Mac mini.
+- A tmux2herdr dry-run saved for reference, for example `tmux2herdr ~/.tmux.conf --dry-run`, never redirected onto `herdr/config.toml`.
+- Explicit yes/no on each recommended decision if the approval reply changed any of them.
+
+**Dependencies:** Herdr binary on PATH (or `~/.local/bin/herdr`). Optional: `cargo install tmux2herdr` or `herdr plugin install sohilladhani/tmux2herdr` for the dry-run.
+
+**Risks:** Treating the dry-run as an apply step would smash the nested-phase config and bind Herdr to `ctrl+a` while tmux is still nested, making both prefixes fight.
+
+**Acceptance criteria:**
+
+- Progress file lists installed Herdr version and whether brew services already manage it.
+- Dry-run output is consulted, not applied.
+- Section 2 decisions are confirmed or amended in the progress file before Phase 2 edits.
+
+### Phase 2 - Move daily panes into Herdr and take the prefix
+
+**Goals:** Stop launching tmux inside Herdr. Make `herdr/config.toml` a standalone multiplexer config.
+
+**Deliverables:**
+
+- Update `herdr/config.toml`:
+  - `onboarding = false`
+  - `[keys] prefix = "ctrl+a"`
+  - Daily key overrides from the table in section 4, merged by hand from the dry-run
+  - `[ui] mouse_capture = true` (already present)
+  - `[terminal] new_cwd = "follow"`
+  - `[session] resume_agents_on_restore = true`
+  - `[ui] window_title = "{hostname}: {workspace}"` if not already the default
+  - hostname on `ui.tab_bar_right` if the version supports that token
+  - do not set `experimental.allow_nested` or `experimental.pane_history`
+- Reload with `herdr server reload-config` (or restart if prefix/startup settings require it).
+- Operator cutover on the Mac mini (not a git operation):
+  1. Snapshot tmux windows/panes.
+  2. In Herdr, create one workspace per project (`herdr workspace create --cwd PATH --label NAME --focus` or the TUI).
+  3. Relaunch agents with their native resume flags if needed.
+  4. Detach/kill the inner tmux server (`tmux kill-server`) only after those panes are no longer the working set.
+- `brew services start herdr` so a reboot restores session shape.
+
+**Dependencies:** Phase 1 inventory. Official integrations installed/updated (`herdr integration install` / `herdr integration status`).
+
+**Risks:** Killing tmux before agents are reattached in Herdr loses in-pane process state. Snapshot restore after `herdr server stop` does not keep arbitrary processes; only native agent restore relaunches supported agent CLIs.
+
+**Acceptance criteria:**
+
+- No pane in the daily Herdr session is running `tmux attach` / `tmux new-session`.
+- `Ctrl+a ?` shows Herdr bindings, not a nested tmux prefix.
+- Detach with `Ctrl+a q` and `herdr` reattaches to the same workspaces.
+- `brew services list` shows herdr started.
+- A pi/claude/cursor-agent pane is detected in the Herdr sidebar.
+
+### Phase 3 - Replace tmux-only scripts and close the SSH fallback
+
+**Goals:** Make PATH utilities and SSH login Herdr-native.
+
+**Deliverables:**
+
+- Rewrite `bin/tat`:
+  - If not inside Herdr and no server is up, start/attach (`herdr`) after ensuring a workspace for `$PWD`.
+  - If a workspace already has cwd/label matching `basename "$PWD"` (or the full path), focus it.
+  - Otherwise `herdr workspace create --cwd "$PWD" --label "$(basename "$PWD")" --focus`.
+  - Do not call `tmux`.
+- Update `zsh/configs/post/ssh-herdr.zsh`:
+  - Keep `exec herdr` as the success path.
+  - Honor `NO_AUTO_HERDR` and `NO_AUTO_TMUX`.
+  - Remove the tmux fallback once Phase 2 is true on both intended Macs; if Herdr is missing, print a one-line error and leave a normal SSH shell.
+- Stop invoking `bin/tmux-agent-sessions` from any remaining tmux config. Leave the script in tree until Phase 5 unless it is already unused.
+- Document `herdr --remote andrews-mac-mini` / `herdr --remote qianas-macbook-pro` in README as optional; do not change auto-attach to that path.
+
+**Dependencies:** Phase 2 config and Mac mini cutover. MacBook changes wait for explicit authorization.
+
+**Risks:** A naive `tat` that always `workspace create` will duplicate workspaces. Must list-and-focus first. SSH fallback removal will strand a host that does not have Herdr installed.
+
+**Acceptance criteria:**
+
+- From a project directory, `tat` focuses an existing matching workspace or creates exactly one new one.
+- Interactive SSH with Herdr installed still `exec`s into that host's session.
+- `NO_AUTO_HERDR=1 ssh …` and `NO_AUTO_TMUX=1 ssh …` both yield a plain shell.
+- `rg tmux bin/tat zsh/configs/post/ssh-herdr.zsh` is empty.
+
+### Phase 4 - Align user and agent documentation
+
+**Goals:** Anyone (including future agent sessions) follows a Herdr-only mental model.
+
+**Deliverables:**
+
+- `CHEATSHEET.md`: one-layer multiplexer. Replace the tmux section with Herdr keys. `tat` row describes workspaces. Reload table and env toggles updated.
+- `README.md`: Herdr as the multiplexer; tmux section becomes a short "removed after soak" note or is deleted in Phase 5. Troubleshooting covers `herdr server reload-config` and missing binary on SSH.
+- `CLAUDE.md`: architecture section describes Herdr, not nested tmux. `tat` description matches the new script.
+- `.agents/skills/tailscale-machine-ops/SKILL.md`: SSH auto-attach is Herdr-only; drop "install tmux for auto-attach."
+
+**Dependencies:** Phases 2–3 so the docs match shipped behavior.
+
+**Risks:** Docs that still mention `Ctrl+b` as the daily prefix will train the wrong muscle memory.
+
+**Acceptance criteria:**
+
+- Cheatsheet mental model is `terminal → herdr → zsh → nvim`.
+- `CHEATSHEET.md` / `README.md` / `CLAUDE.md` no longer instruct the reader to nest tmux inside Herdr.
+- Tailscale skill does not tell agents to `brew install tmux` for SSH.
+
+### Phase 5 - Retire tracked tmux config after soak
+
+**Goals:** tmux is no longer part of the installed dotfiles.
+
+**Deliverables:**
+
+- Remove or archive `tmux.conf`, `.tmux/` (if tracked), and `bin/tmux-agent-sessions`.
+- Confirm `install.sh` skip list does not need a new exception (deleting `tmux.conf` is enough; it will no longer be symlinked).
+- Leave existing `~/.tmux.conf` / `~/.tmux` on disk until the operator deletes those symlinks locally; `install.sh` must not force-delete them.
+- Keep the Homebrew tmux formula installed until a later explicit uninstall request.
+
+**Dependencies:** Successful soak on the Mac mini (and MacBook if authorized): several detach/reattach cycles, one reboot or `brew services restart herdr`, and one SSH attach.
+
+**Risks:** Deleting tracked tmux too early leaves no rollback in the repo. Rollback is `git checkout` of this plan's parent plus `tmux source-file ~/.tmux.conf`.
+
+**Acceptance criteria:**
+
+- `git ls-files` no longer contains `tmux.conf` or `bin/tmux-agent-sessions`.
+- `./install.sh` still links Herdr config and does not warn about `tmux.conf`.
+- Emergency hatch is documented: `brew install tmux` plus checking out the last commit that had `tmux.conf`.
+
+### Phase 6 - Verify, ship, archive
+
+**Goals:** Dual-machine verification where authorized, then a focused PR and archive of these planning files.
+
+**Deliverables:**
+
+- Mac mini verification matrix (below).
+- MacBook verification only with explicit authorization: `git pull`, `./install.sh`, `herdr server reload-config`, `brew services start herdr`, SSH from the mini.
+- Shipping PR on `feat/herdr-full-migration`.
+- After merge: move this plan and progress file to `docs/archive/` via `.claude/skills/arc-implementation-plan-progress/scripts/archive_plan.sh`.
+
+**Verification matrix (user-facing, not implementation-coupled):**
+
+1. `herdr --version` and `herdr status` succeed.
+2. `Ctrl+a ?` lists the documented bindings.
+3. Split, hjkl, new tab, zoom, copy-mode yank, and detach/reattach work in a scratch workspace.
+4. `tat` from a repo directory focuses or creates one workspace labeled with that basename.
+5. Interactive SSH from the other Mac attaches the existing Herdr session without starting tmux.
+6. `NO_AUTO_HERDR=1 ssh …` is a plain shell.
+7. After `brew services restart herdr` (or reboot), workspaces/tabs/cwds return; supported agent panes resume conversations rather than empty shells.
+8. `herdr integration status` shows current integrations for the agents actually running.
+9. No daily pane is a nested tmux client (`ps` / pane command is zsh, nvim, or an agent).
+
+**Dependencies:** Phases 2–5. GitHub push/PR only when explicitly requested.
+
+**Risks:** Prefix change requires a server restart, not only `reload-config`. Test that explicitly.
+
+**Acceptance criteria:**
+
+- Matrix items 1–9 pass on the Mac mini.
+- MacBook items pass if authorization was given; otherwise they are listed as deferred in the PR body.
+- Planning files move to `docs/archive/` after the shipping PR merges.
+
+## 6. Out of scope / deferred
+
+- Uninstalling Homebrew `tmux`.
+- Host-specific green/blue/yellow accent colors.
+- Battery widget in the Herdr tab bar.
+- `experimental.pane_history`.
+- Switching SSH auto-attach to `herdr --remote`.
+- herdr-spreader / saved multi-pane layout files.
+- Automatic tab rename via zsh `preexec` hooks.
+- Prefix-free `ctrl+alt` chords.
+- Migrating other machines beyond the two known Tailscale Macs.
+- Changing Neovim tmux-unrelated settings.
+
+## 7. Immediate next steps
+
+1. Confirm or amend the section 2 decisions (especially prefix `ctrl+a`, dropping host colors, and keeping brew tmux installed).
+2. On the Mac mini, record the Phase 1 inventory commands into `docs/herdr-full-migration-progress.txt`.
+3. After approval, implement Phase 2 config in `herdr/config.toml` on branch `feat/herdr-full-migration` before any tmux kill-server.
+4. Recreate workspaces in Herdr, then kill the nested tmux server.
+5. Only then rewrite `tat` and drop the SSH tmux fallback.
+
+Do not start file changes until this plan is approved.

--- a/docs/herdr-full-migration-progress.txt
+++ b/docs/herdr-full-migration-progress.txt
@@ -1,0 +1,64 @@
+herdr-full-migration - Herdr Full-Time Migration - Progress
+Generated: 2026-08-21 10:25:00 EDT
+Updated: 2026-08-21 10:45:00 EDT
+Cutover: 2026-08-21 10:50:00 EDT
+Plan: docs/herdr-full-migration-IMPLEMENTATION_PLAN.md
+On completion, move this file and the plan to docs/archive/.
+
+Phase 1 inventory (Andrews-Mac-mini, 2026-08-21):
+- herdr 0.8.0 at ~/.local/bin/herdr (direct install; Homebrew formula herdr 0.8.2 is available but not installed)
+- herdr status: server running, protocol 19, socket ~/.config/herdr/herdr.sock
+- brew services: no herdr service (formula not installed, so brew services start herdr is blocked until brew install herdr)
+- integrations current: pi v8, claude v7, cursor v1, plus codex/droid/opencode/kilo/hermes
+- tmux2herdr: not installed; keys hand-merged from tmux.conf
+- MacBook Herdr/tmux state: unknown (not authorized)
+
+Cutover (2026-08-21):
+- Created Herdr workspaces: arc-board, arc-skill-eval, sprtsmng, kingstonsolomon, myresume, arc-orchestrator, orchestrator, arc-worlds, arc-clis, arc-sim, codebase-atlas (plus existing ~, pi-extend, arc-chalk, arc-fnm, dotfiles)
+- Agent resume map written to ~/.config/herdr/tmux-cutover-restore.tsv (not git)
+- herdr server reload-config applied; dropped 0.8.0-unknown keys (tab_bar_right, window_title); last_pane is prefix+semicolon
+- tmux kill-server scheduled as the live cutover
+- brew services still blocked: herdr is ~/.local/bin, not the Homebrew formula
+
+Section 2 decisions (confirmed by execute request, unchanged):
+prefix ctrl+a; one session + workspaces; drop host colors; keep brew tmux; SSH stays exec herdr; keep NO_AUTO_TMUX plus NO_AUTO_HERDR.
+
+[x] 1.0 - Phase 1 - Inventory the live nested setup and confirm decisions
+    [x] 1.1 - Record Mac mini herdr --version, herdr status, brew services list, and herdr integration status in this file
+    [x] 1.2 - Dump tmux ls and tmux list-windows -a (plus pane commands) as the cutover inventory; do not kill tmux yet
+    [x] 1.3 - Run tmux2herdr ~/.tmux.conf --dry-run (or herdr plugin preview) and keep the output as reference only
+    [x] 1.4 - Confirm section 2 decisions: prefix ctrl+a, one session + workspaces, drop host colors, keep brew tmux, SSH stays exec herdr
+    [x] 1.5 - Note MacBook Herdr/tmux state as unknown until explicitly authorized
+
+[x] 2.0 - Phase 2 - Move daily panes into Herdr and take the prefix
+    [x] 2.1 - Hand-merge herdr/config.toml: prefix ctrl+a, daily splits/hjkl/tabs/zoom/copy/detach/reload, new_cwd follow, resume_agents_on_restore, onboarding false
+    [x] 2.2 - Leave experimental.allow_nested and experimental.pane_history unset/false; do not redirect tmux2herdr onto config.toml
+    [x] 2.3 - Install/upgrade official Herdr integrations for pi, Claude Code, and Cursor Agent; verify herdr integration status
+    [x] 2.4 - herdr server reload-config, and restart the server if prefix does not apply until restart
+    [x] 2.5 - Recreate one Herdr workspace per active project from the Phase 1 inventory and relaunch agents with native resume flags
+    [x] 2.6 - Confirm no daily pane is tmux attach, then tmux kill-server on the Mac mini
+    [ ] 2.7 - brew services start herdr and verify detach Ctrl+a q / reattach herdr restores the same workspaces
+
+[x] 3.0 - Phase 3 - Replace tmux-only scripts and close the SSH fallback
+    [x] 3.1 - Rewrite bin/tat to list-and-focus a matching Herdr workspace or create --cwd "$PWD" --label basename --focus; never call tmux
+    [x] 3.2 - Update zsh/configs/post/ssh-herdr.zsh to honor NO_AUTO_HERDR and NO_AUTO_TMUX, keep exec herdr, and remove the tmux fallback
+    [x] 3.3 - Document optional herdr --remote <host> in README without changing auto-attach to that path
+    [x] 3.4 - Verify tat from a repo dir focuses or creates exactly one workspace, and SSH still lands in the existing Herdr session
+
+[x] 4.0 - Phase 4 - Align user and agent documentation
+    [x] 4.1 - Rewrite CHEATSHEET.md mental model to terminal → herdr → zsh → nvim and replace the tmux key tables with Herdr
+    [x] 4.2 - Update README.md multiplexer/SSH/reload/troubleshooting sections to Herdr-only
+    [x] 4.3 - Update CLAUDE.md architecture, reload, tat, and SSH auto-attach to match shipped Herdr behavior
+    [x] 4.4 - Update .agents/skills/tailscale-machine-ops/SKILL.md so agents no longer install or attach tmux for SSH
+
+[ ] 5.0 - Phase 5 - Retire tracked tmux config after soak
+    [ ] 5.1 - Soak on the Mac mini: multiple detach/reattach cycles, one brew services restart herdr or reboot, one SSH attach
+    [ ] 5.2 - Remove tmux.conf, bin/tmux-agent-sessions, and tracked .tmux/ plugin tree from the repo
+    [ ] 5.3 - Confirm install.sh still links Herdr config and no longer creates a new ~/.tmux.conf; do not delete existing home symlinks from install.sh
+    [ ] 5.4 - Document the emergency hatch (keep brew tmux installed; restore tmux.conf from git history) and do not brew uninstall tmux
+
+[ ] 6.0 - Phase 6 - Verify, ship, and archive
+    [ ] 6.1 - Run the Mac mini verification matrix from the plan (keys, tat, SSH, NO_AUTO_HERDR, agent resume, no nested tmux)
+    [ ] 6.2 - With explicit authorization only, pull/install/reload on qianas-macbook-pro and repeat SSH/tat/services checks
+    [x] 6.3 - Open the shipping PR on feat/herdr-full-migration only when explicitly requested
+    [ ] 6.4 - On merge: move docs/herdr-full-migration-IMPLEMENTATION_PLAN.md and docs/herdr-full-migration-progress.txt to docs/archive/

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -1,5 +1,6 @@
 onboarding = false
 # Herdr is the multiplexer. Prefix is Ctrl+a (same chord as the old tmux config).
+# Keys limited to herdr 0.8.0 (tab_bar_right / window_title are newer).
 
 [session]
 resume_agents_on_restore = true
@@ -8,8 +9,13 @@ resume_agents_on_restore = true
 agent_panel_sort = "spaces"
 mouse_capture = true
 
+[terminal]
+new_cwd = "follow"
+
 [keys]
 prefix = "ctrl+a"
+# prefix+ctrl+a is reserved (sends a literal prefix). tmux last-pane was `;`.
+last_pane = "prefix+semicolon"
 
 # Keep Control held after the prefix. Without these aliases Herdr sees ctrl+h
 # (etc.), finds no binding, and silently drops the key.
@@ -24,8 +30,8 @@ focus_pane_left = ["prefix+h", "prefix+ctrl+h"]
 focus_pane_down = ["prefix+j", "prefix+ctrl+j"]
 focus_pane_up = ["prefix+k", "prefix+ctrl+k"]
 focus_pane_right = ["prefix+l", "prefix+ctrl+l"]
-split_vertical = ["prefix+v", "prefix+ctrl+v"]
+split_vertical = ["prefix+v", "prefix+ctrl+v", "prefix+%", "prefix+|"]
 split_horizontal = ["prefix+minus", "prefix+ctrl+minus"]
 close_pane = ["prefix+x", "prefix+ctrl+x"]
-zoom = ["prefix+z", "prefix+ctrl+z"]
+zoom = ["prefix+z", "prefix+ctrl+z", "prefix+plus"]
 toggle_sidebar = ["prefix+b", "prefix+ctrl+b"]

--- a/install.sh
+++ b/install.sh
@@ -146,6 +146,25 @@ if [ -f /etc/os-release ] && grep -q '^ID=omarchy$' /etc/os-release; then
   install_omarchy_xcompose
 fi
 
+# ~/.bin is on PATH (zsh/configs/post/path.zsh). If it is already a real
+# directory, the top-level loop cannot replace it with a symlink to bin/, so
+# link each executable into ~/.bin the same way npxt3 was installed.
+if [ -d bin ] && [ -d "$HOME/.bin" ] && [ ! -L "$HOME/.bin" ]; then
+  for script in bin/*; do
+    [ -f "$script" ] && [ -x "$script" ] || continue
+    name="$(basename "$script")"
+    target="$HOME/.bin/$name"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+      if [ ! -L "$target" ]; then
+        echo "WARNING: $target exists but is not a symlink."
+      fi
+    else
+      echo "Creating $target"
+      ln -s "$PWD/$script" "$target"
+    fi
+  done
+fi
+
 mkdir -p "$HOME/.config/nvim"
 if [ ! -f "$HOME/.config/nvim/init.vim" ]; then
   printf 'source ~/.vimrc\n' > "$HOME/.config/nvim/init.vim"

--- a/vimrc.plugins
+++ b/vimrc.plugins
@@ -16,6 +16,32 @@ noremap <C-T> :NERDTreeToggle<CR>
 nmap <leader>n :NERDTreeFind<CR>R
 autocmd vimenter * NERDTree
 autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTree") && b:NERDTree.isTabTree()) | q | endif
+
+function! s:NERDTreeIsVisible() abort
+  if !exists('g:NERDTree') || !g:NERDTree.IsOpen()
+    return 0
+  endif
+  let l:winnr = g:NERDTree.GetWinNum()
+  return l:winnr > 0 && winwidth(l:winnr) > 0 && winheight(l:winnr) > 0
+endfunction
+
+function! s:NERDTreeMaybeRefresh() abort
+  if !s:NERDTreeIsVisible()
+    return
+  endif
+  silent! NERDTreeRefreshRoot
+endfunction
+
+augroup NERDTreeAutoRefresh
+  autocmd!
+  " Pick up files created/changed outside nvim (git, touch, another app)
+  autocmd FocusGained * call s:NERDTreeMaybeRefresh()
+  " Pick up files created/saved/deleted inside nvim
+  autocmd BufWritePost,BufDelete * call s:NERDTreeMaybeRefresh()
+  " Pick up files from shell commands (:!, :terminal)
+  autocmd ShellCmdPost * call s:NERDTreeMaybeRefresh()
+augroup END
+
 " Nerd Font fallback:
 " - Use Nerd Font icons by default.
 " - Set DOTFILES_NERD_FONT=0 to force ASCII-safe rendering on machines without Nerd Fonts.

--- a/zsh/configs/post/ssh-herdr.zsh
+++ b/zsh/configs/post/ssh-herdr.zsh
@@ -1,10 +1,10 @@
 # Auto-attach interactive SSH shells to the host's Herdr session.
 # Skip inside an existing Herdr pane (HERDR_ENV=1) so we do not exec a nested
-# client. NO_AUTO_TMUX=1 remains the escape hatch (plain remote shell).
+# client. NO_AUTO_HERDR=1 and NO_AUTO_TMUX=1 are escape hatches (plain remote shell).
 #
 # `herdr` often lives in ~/.local/bin, which is appended later in zshrc, so
-# look there explicitly. Fall back to tmux when Herdr is not installed.
-if [[ -o interactive && -n "$SSH_CONNECTION" && -z "$TMUX" && -z "$HERDR_ENV" && -z "$NO_AUTO_TMUX" ]]; then
+# look there explicitly. If Herdr is missing, keep a normal SSH shell.
+if [[ -o interactive && -n "$SSH_CONNECTION" && -z "$TMUX" && -z "$HERDR_ENV" && -z "$NO_AUTO_TMUX" && -z "$NO_AUTO_HERDR" ]]; then
   _ssh_herdr=""
   if command -v herdr >/dev/null 2>&1; then
     _ssh_herdr="$(command -v herdr)"
@@ -14,8 +14,7 @@ if [[ -o interactive && -n "$SSH_CONNECTION" && -z "$TMUX" && -z "$HERDR_ENV" &&
 
   if [[ -n "$_ssh_herdr" ]]; then
     exec "$_ssh_herdr"
-  elif command -v tmux >/dev/null 2>&1; then
-    _ssh_tmux_host="${HOST%%.*}"
-    exec tmux new-session -A -s "ssh-${_ssh_tmux_host:-remote}"
+  else
+    print -u2 "ssh-herdr: herdr not found; starting a plain shell (install herdr, or set NO_AUTO_HERDR=1)."
   fi
 fi


### PR DESCRIPTION
## Summary
- Make Herdr the daily multiplexer: `tat` focuses or creates a workspace for `$PWD`, SSH auto-attach no longer falls back to tmux, and `NO_AUTO_HERDR=1` is the documented plain-shell hatch.
- Keep the existing `ctrl+a` held-key aliases from main, and add `new_cwd = follow`, last-pane `;`, and extra split/zoom chords. `tmux.conf` stays as a soak-period emergency hatch.
- Refresh NERDTree when the tree is actually visible so files created outside nvim show up without refreshing a hidden sidebar.
- Installer now links executables into an existing `~/.bin` directory so `tat` resolves on PATH.

## Test plan
- [ ] `tat` from a repo directory focuses an existing matching workspace or creates one labeled with `basename $PWD`
- [ ] Interactive SSH still lands in the host Herdr session; `ssh -t mini 'NO_AUTO_HERDR=1 exec zsh -l'` stays a plain shell
- [ ] Missing Herdr prints the warning and leaves a normal SSH shell (no tmux)
- [ ] `Ctrl+a` splits, hjkl, detach `q`, last pane `;`, and held-control aliases still work after `herdr server reload-config` (restart if prefix bindings do not apply)
- [ ] New files appear in NERDTree after focus/save when the tree is open, and no refresh runs when it is hidden
- [ ] `./install.sh` still installs ssh/omarchy/herdr as before, and links `bin/tat` into `~/.bin` when that directory already exists


Made with [Cursor](https://cursor.com)