### PR TITLE
feat: show ARC Pi prompts in Herdr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,11 @@ Tailscale Macs: `andrews-mac-mini` / `Andrews-Mac-mini` is green,
 symlinks it to `~/.config/herdr/config.toml`. Prefix is `ctrl+a`. Completions live in
 `zsh/completion/_herdr`.
 
+Herdr in-app toasts are enabled for ARC Pi operator prompts. ARC Pi publishes a
+blocked agent state while a question or approval is open and clears it when the
+prompt settles; the notification label is generic and does not expose question
+text.
+
 ### bin/ utilities (on PATH)
 
 - `generate-vim-plugin-inventory` — see above.

--- a/README.md
+++ b/README.md
@@ -303,6 +303,11 @@ uses `~/.arc-pi`. After the first installation, already-running Pi panes need
 `/reload` before they can use the integration. Diagnose an installation with
 `herdr integration status`.
 
+ARC Pi publishes a blocked agent state while an operator question or approval is
+open. Herdr renders that state as an in-app toast (`[ui.toast] delivery =
+"herdr"`) and clears it when the prompt is answered, cancelled, or fails. The
+notification uses a generic label and never includes the question text.
+
 zsh completion is generated into [`zsh/completion/_herdr`](zsh/completion/_herdr)
 (`herdr completion zsh`). Re-source `~/.zshrc` (or open a new shell) after install.
 

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -8,6 +8,11 @@ resume_agents_on_restore = true
 agent_panel_sort = "spaces"
 mouse_capture = true
 
+# Show ARC Pi prompts that are waiting for operator input inside Herdr.
+[ui.toast]
+delivery = "herdr"
+delay_seconds = 0
+
 [keys]
 prefix = "ctrl+a"
 


### PR DESCRIPTION
## Summary
- enable immediate Herdr in-app toasts for ARC Pi operator prompts
- document blocked-state toast behavior and privacy guarantees
- record the integration in repository guidance

## Verification
- parsed `herdr/config.toml` with Python `tomllib`
- confirmed toast delivery is `herdr` with a zero-second delay
- ran `git diff --check`